### PR TITLE
Remove setting of resources on the VM spec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,7 @@
 		"Install Kubevirt krew plugin": "kubectl krew install virt"
 	},
 	"mounts": [
-		"source=${localWorkspaceFolder}/.kube,target=/home/vscode/.kube,type=bind,consistency=cached",
+		"type=bind,src=${localEnv:HOME}/.kube,dst=/home/vscode/.kube,consistency=cached",
 	]
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -412,16 +412,6 @@ module Beaker
                 'memory' => {
                   'guest' => memory.to_s,
                 },
-                'resources' => {
-                  'limits' => {
-                    'cpu' => cpu.to_s,
-                    'memory' => memory.to_s,
-                  },
-                  'requests' => {
-                    'cpu' => '125m',
-                    'memory' => '1Gi',
-                  },
-                },
                 'devices' => generate_hardware_spec(host),
                 'features' => {
                   'acpi' => {},


### PR DESCRIPTION
Setting the requests and limits overrides KubeVirt's defaults which can lead to OOM kills