### PR TITLE
Add error handling to VM creation in provision

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -100,6 +100,10 @@ module Beaker
 
       @hosts.each do |host|
         create_vm(host)
+      rescue StandardError, Interrupt => e
+        @logger.error("Error creating VM for host #{host.name}: #{e.message}")
+        cleanup
+        raise e
       end
 
       @hosts.each do |host|


### PR DESCRIPTION
## Summary
- Add rescue block to first host loop in `provision()` so VM creation failures trigger cleanup
- Previously only the second loop (wait_for_vm_ready + setup_networking) had error handling

## Test plan
- [ ] `bundle exec rake spec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)