### PR TITLE
Fix SSH key path expansion

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -339,7 +339,8 @@ module Beaker
     def find_ssh_key_pair
       if @options[:kubevirt_ssh_key]
         # If kubevirt_ssh_key is specified, it could be a public key path/content
-        ssh_key_path = File.expand_path(@options[:kubevirt_ssh_key])
+        ssh_key_value = @options[:kubevirt_ssh_key]
+        ssh_key_path = ssh_key_value.match?(%r{^[~/.]}) ? File.expand_path(ssh_key_value) : ssh_key_value
         if File.exist?(ssh_key_path)
           pub_key_path = ssh_key_path
           pub_key_content = File.read(pub_key_path).strip

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -339,8 +339,9 @@ module Beaker
     def find_ssh_key_pair
       if @options[:kubevirt_ssh_key]
         # If kubevirt_ssh_key is specified, it could be a public key path/content
-        if File.exist?(@options[:kubevirt_ssh_key])
-          pub_key_path = @options[:kubevirt_ssh_key]
+        ssh_key_path = File.expand_path(@options[:kubevirt_ssh_key])
+        if File.exist?(ssh_key_path)
+          pub_key_path = ssh_key_path
           pub_key_content = File.read(pub_key_path).strip
 
           # Try to find matching private key


### PR DESCRIPTION
## Summary
- Use `File.expand_path` on SSH key paths so `~/.ssh/id_rsa.pub` works correctly
- Ruby's `File.exist?` doesn't expand `~` like a shell does

## Test plan
- [ ] `bundle exec rake spec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)