### PR TITLE
Add error handling for cloud-init YAML parsing

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -323,7 +323,11 @@ module Beaker
 
       # Add custom cloud-init if provided
       if @options[:cloud_init]
-        custom_init = YAML.safe_load(@options[:cloud_init])
+        begin
+          custom_init = YAML.safe_load(@options[:cloud_init])
+        rescue Psych::SyntaxError => e
+          raise ArgumentError, "Invalid cloud-init YAML in kubevirt_cloud_init option: #{e.message}"
+        end
         cloud_init = cloud_init.merge(custom_init)
       end
       # It looks like the ssh-key is being wrapped to a new line by default, so we need to ensure it is properly formatted


### PR DESCRIPTION
## Summary
- Wrap `YAML.safe_load` for cloud-init with a rescue for `Psych::SyntaxError`
- Raises `ArgumentError` with a clear message instead of a cryptic Psych error

## Test plan
- [ ] `bundle exec rake spec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)