### PR TITLE
Add bug tracker URI to gemspec metadata

### DIFF
--- a/beaker-kubevirt.gemspec
+++ b/beaker-kubevirt.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata['bug_tracker_uri'] = "#{spec.homepage}/issues"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Summary
- Add `bug_tracker_uri` to gemspec metadata so RubyGems links to the issue tracker

## Test plan
- [ ] `gem build beaker-kubevirt.gemspec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)