### PR TITLE
Add Ruby 4.0 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
             coverage: "yes"
           - ruby: "3.3"
           - ruby: "3.4"
+          - ruby: "4.0"
     env:
       COVERAGE: ${{ matrix.coverage }}
     name: Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to the CI test matrix alongside 3.2, 3.3, and 3.4

## Test plan
- [ ] CI passes on Ruby 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)