### PR TITLE
Fix Windows VM OOMKills and fail fast on virt-launcher pod failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `kubevirt_memory_overhead` (default `512Mi`) and `kubevirt_memory_request` options.
+  The VM spec now sets `spec.template.spec.domain.resources.requests/limits.memory`
+  explicitly (guest + overhead for the limit) so Windows guests no longer get
+  OOMKilled by KubeVirt's too-small auto-computed virt-launcher overhead.
+- `wait_for_vm_ready` now inspects the virt-launcher pod each poll and fails
+  fast with a specific reason (OOMKilled, CrashLoopBackOff, ImagePullBackOff,
+  terminal VMI phase, ...) instead of hanging for the full timeout.
 - Initial implementation of KubeVirt hypervisor provider for Beaker
 - Support for VM provisioning using KubeVirt VirtualMachine objects
 - Multiple image source support (PVC, ContainerDisk, DataVolume)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wait_for_vm_ready` now inspects the virt-launcher pod each poll and fails
   fast with a specific reason (OOMKilled, CrashLoopBackOff, ImagePullBackOff,
   terminal VMI phase, ...) instead of hanging for the full timeout.
+- TCP `readinessProbe` on the guest's SSH port is added to the VM spec by
+  default (for `port-forward` and `nodeport` network modes; skipped for
+  `multus`). `wait_for_vm_ready` now waits for the VMI's `Ready` condition to
+  flip to `True`, so provisioning only hands off to Beaker once sshd is
+  actually accepting connections — no more SSH "connection refused" retries
+  while cloud-init / Windows first-boot is still running. Tunable via
+  `kubevirt_readiness_probe` and opt-out via `kubevirt_readiness_probe_disabled`.
+  When the probe is enabled, `timeout` is auto-raised to fit the probe's
+  failure budget.
 - Initial implementation of KubeVirt hypervisor provider for Beaker
 - Support for VM provisioning using KubeVirt VirtualMachine objects
 - Multiple image source support (PVC, ContainerDisk, DataVolume)

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -124,6 +124,36 @@ The gem is ready for:
 - Community feedback and contributions
 - Enhancement based on user needs
 
+## Developer Gotchas
+
+### `Beaker::Host` does not support `key?`
+
+`Beaker::Host` (and subclasses like `PSWindows::Host`) proxy `[]` and `[]=`
+to an internal options hash but do **not** expose `key?`, `fetch`, `dig`, or
+other `Hash` methods. Calling them raises `NoMethodError` at runtime —
+silently passing unit specs that use plain `Hash` fixtures for hosts.
+
+Do not write:
+
+```ruby
+return host['foo'] if host.key?('foo')
+```
+
+Instead, treat `nil` as "unset" so both presence and an explicit `false`
+are preserved:
+
+```ruby
+val = host['foo']
+return val unless val.nil?
+```
+
+See `readiness_probe_disabled?` in `lib/beaker/hypervisor/kubevirt.rb` for
+the canonical pattern, and `vm_ssh_port` for the simpler `host['x'] || default`
+form when `false` isn't a meaningful value. When the distinction between
+"unset" and "explicitly false" matters for a new option, add an acceptance
+or integration-level test — unit tests with `Hash` fixtures will not catch
+the `key?` failure.
+
 ## Integration with Beaker Ecosystem
 
 This implementation follows established Beaker patterns (similar to beaker-google, beaker-aws, etc.) ensuring:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ CONFIG:
 | `kubevirt_ssh_key` | SSH public key path or content | Yes | Auto-detect from `~/.ssh/` | HOSTS (per-host) |
 | `kubevirt_cpus` | CPU cores for VM | No | `1` | HOSTS (per-host) |
 | `kubevirt_memory` | Memory for VM | No | `2Gi` | HOSTS (per-host) |
+| `kubevirt_memory_overhead` | Extra memory added to the guest for the virt-launcher container memory limit. Raise this for Windows guests that OOMKill with the default. | No | `512Mi` | HOSTS (per-host), CONFIG |
+| `kubevirt_memory_request` | Memory request for the VM pod. | No | Same as `kubevirt_memory` | HOSTS (per-host), CONFIG |
 | `kubevirt_disk_size` | Size of the root disk | No | `10Gi` | HOSTS (per-host) |
 | `kubevirt_cloud_init` | Custom cloud-init YAML | No | Auto-generated | HOSTS (per-host) |
 | `kubevirt_vm_ssh_port` | SSH port inside the VM | No | `22` | HOSTS (per-host) |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ CONFIG:
 | `kubevirt_disk_size` | Size of the root disk | No | `10Gi` | HOSTS (per-host) |
 | `kubevirt_cloud_init` | Custom cloud-init YAML | No | Auto-generated | HOSTS (per-host) |
 | `kubevirt_vm_ssh_port` | SSH port inside the VM | No | `22` | HOSTS (per-host) |
+| `kubevirt_readiness_probe_disabled` | Skip the VMI SSH readinessProbe. Default is `false` for pod-network modes and `true` for `multus` (where a probe from the virt-launcher netns typically can't reach a bridge-only guest). | No | mode-dependent | HOSTS (per-host), CONFIG |
+| `kubevirt_readiness_probe` | Probe tuning hash (snake_case keys): `initial_delay_seconds` (30), `period_seconds` (10), `timeout_seconds` (3), `failure_threshold` (60), `success_threshold` (1). The default failure budget (600s) accommodates slow Windows first-boots. When the probe is enabled, `timeout` is auto-raised to cover this budget. | No | see description | HOSTS (per-host), CONFIG |
 | `kubevirt_disable_virtio` | Disable virtio devices (for Windows compatibility). If set to true the disk bus will be set to `sata` and the network adapter will be model `e1000` | No | `false` | HOSTS (per-host) |
 
 **Important**: The `namespace`, `kubeconfig`, and `kubecontext` options must be specified in the global `CONFIG` section, not per-host. All VMs will be created in the same Kubernetes namespace.

--- a/examples/hosts.yaml
+++ b/examples/hosts.yaml
@@ -9,6 +9,10 @@ HOSTS:
     kubevirt_ssh_key: ~/.ssh/id_rsa.pub
     kubevirt_cpus: 2
     kubevirt_memory: 4Gi
+    # Extra memory added to the guest for the virt-launcher container memory
+    # limit. Bump this for Windows guests that get OOMKilled with the default.
+    kubevirt_memory_overhead: 512Mi
+    # kubevirt_memory_request: 4Gi   # defaults to kubevirt_memory
     # Beaker-specific configuration
     user: centos
     ssh:

--- a/examples/hosts.yaml
+++ b/examples/hosts.yaml
@@ -13,6 +13,12 @@ HOSTS:
     # limit. Bump this for Windows guests that get OOMKilled with the default.
     kubevirt_memory_overhead: 512Mi
     # kubevirt_memory_request: 4Gi   # defaults to kubevirt_memory
+    # Optional: tune the SSH readinessProbe (KubeVirt runs this from virt-launcher,
+    # flips the VMI Ready condition to True once sshd is accepting connections).
+    # kubevirt_readiness_probe:
+    #   initial_delay_seconds: 30
+    #   period_seconds: 10
+    #   failure_threshold: 120   # 120 * 10s = 20 min, for very slow Windows first-boots
     # Beaker-specific configuration
     user: centos
     ssh:

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -71,7 +71,16 @@ module Beaker
     # @option options [String] :kubevirt_memory_request Memory request for the VM pod
     #   (default: same as :kubevirt_memory).
     # @option options [Integer] :kubevirt_vm_ssh_port Port that SSH runs on inside the VM (default: 22)
-    # @option options [Integer] :timeout Timeout for operations
+    # @option options [Boolean] :kubevirt_readiness_probe_disabled Skip the VMI SSH
+    #   readinessProbe. Defaults to false for pod-network modes (port-forward, nodeport)
+    #   and true for multus (the tcpSocket probe runs from the virt-launcher pod's
+    #   network namespace and typically can't reach a bridge-only guest on a secondary NIC).
+    # @option options [Hash] :kubevirt_readiness_probe Probe tuning (all optional, snake_case):
+    #   :initial_delay_seconds (30), :period_seconds (10), :timeout_seconds (3),
+    #   :failure_threshold (60), :success_threshold (1). The default failure budget
+    #   (period_seconds * failure_threshold = 600s) accommodates slow Windows first-boots.
+    # @option options [Integer] :timeout Timeout for operations. When the readiness probe is
+    #   enabled, the effective wait is max(:timeout, probe budget + 60s).
     # @option options [Boolean] :kubevirt_disable_virtio Disable virtio devices (for compatibility with Windows)
     def initialize(kubevirt_hosts, options)
       require 'beaker/hypervisor/kubevirt_helper'
@@ -535,6 +544,7 @@ module Beaker
               },
               'hostname' => host_name,
               'networks' => generate_networks_spec(host),
+              'readinessProbe' => generate_readiness_probe_spec(host),
               'volumes' => [
                 generate_root_volume_spec(vm_image, host),
                 {
@@ -547,7 +557,7 @@ module Beaker
                 },
                 generate_service_account_volume_spec,
               ].compact,
-            },
+            }.compact,
           },
         },
       }
@@ -688,7 +698,9 @@ module Beaker
       vm_name = host['vm_name']
       @logger.info("Waiting for VM #{vm_name} to be ready...")
 
-      timeout = @options[:timeout] || 300
+      probe = generate_readiness_probe_spec(host)
+      timeout = effective_ready_timeout(probe)
+
       begin
         Timeout.timeout(timeout) do
           loop do
@@ -710,8 +722,9 @@ module Beaker
             # Then check if the VM is running
             vmi = @kubevirt_helper.get_vmi(vm_name)
             phase = vmi&.dig('status', 'phase')
-            if phase == 'Running'
-              @logger.debug("VM #{vm_name} is running")
+
+            if phase == 'Running' && vmi_ssh_ready?(vmi, probe)
+              @logger.debug("VM #{vm_name} is ready")
               break
             end
 
@@ -726,6 +739,45 @@ module Beaker
         @logger.error("Timeout waiting for VM #{vm_name} to be ready")
         raise
       end
+    end
+
+    ##
+    # Whether the VMI is fully ready. If a readiness probe is configured,
+    # require the KubeVirt-managed `Ready` status condition to be True (that
+    # tracks the tcpSocket probe, so sshd is actually listening). Otherwise
+    # fall back to phase=Running alone — the historical behavior.
+    # @param [Hash] vmi VMI object from the kubevirt API
+    # @param [Hash, nil] probe The probe spec, or nil when disabled
+    # @return [Boolean]
+    def vmi_ssh_ready?(vmi, probe)
+      return true if probe.nil?
+
+      condition = Array(vmi&.dig('status', 'conditions'))
+                  .find { |c| c['type'] == 'Ready' }
+      if condition.nil?
+        @logger.debug('VMI has no Ready condition yet, continuing to wait')
+        return false
+      end
+      return true if condition['status'] == 'True'
+
+      @logger.debug("VMI Ready=#{condition['status']} reason=#{condition['reason']} message=#{condition['message']}")
+      false
+    end
+
+    ##
+    # Compute the effective outer Timeout for wait_for_vm_ready. When a probe
+    # is configured, the probe's worst-case budget (initial delay + period *
+    # failureThreshold) must fit, otherwise a user who left :timeout at the
+    # default would see the probe truncated before it can fail legitimately.
+    # @param [Hash, nil] probe
+    # @return [Integer] seconds
+    def effective_ready_timeout(probe)
+      base = @options[:timeout] || 300
+      return base if probe.nil?
+
+      probe_budget = probe['initialDelaySeconds'] +
+                     (probe['periodSeconds'] * probe['failureThreshold']) + 60
+      [base, probe_budget].max
     end
 
     ##
@@ -760,16 +812,61 @@ module Beaker
     end
 
     ##
+    # The guest-side port SSH listens on, shared between the VMI readiness probe
+    # and client-side networking setup so they can never drift apart.
+    # @param [Host] host The host configuration
+    # @return [Integer] SSH port inside the guest
+    def vm_ssh_port(host)
+      host['kubevirt_vm_ssh_port'] || @options[:kubevirt_vm_ssh_port] || 22
+    end
+
+    ##
+    # Whether the SSH readinessProbe should be skipped for this host.
+    # Defaults to false for pod-network modes (port-forward, nodeport) and true
+    # for multus (the probe runs from the virt-launcher pod's netns and
+    # typically can't reach a bridge-only guest on a secondary interface).
+    # @param [Host] host The host configuration
+    # @return [Boolean]
+    def readiness_probe_disabled?(host)
+      return host['kubevirt_readiness_probe_disabled'] if host.key?('kubevirt_readiness_probe_disabled')
+      return @options[:kubevirt_readiness_probe_disabled] if @options.key?(:kubevirt_readiness_probe_disabled)
+
+      (host['kubevirt_network_mode'] || 'port-forward') == 'multus'
+    end
+
+    ##
+    # Build the KubeVirt readinessProbe hash for a host, or nil if disabled.
+    # A tcpSocket probe on the guest's SSH port lets KubeVirt publish a
+    # Ready condition once sshd is actually accepting connections — wait_for_vm_ready
+    # gates on that condition so Beaker doesn't attempt SSH before the guest is up.
+    # Per-host overrides win over global options; snake_case keys map to the
+    # camelCase probe fields KubeVirt expects.
+    # @param [Host] host The host configuration
+    # @return [Hash, nil]
+    def generate_readiness_probe_spec(host)
+      return nil if readiness_probe_disabled?(host)
+
+      cfg = (@options[:kubevirt_readiness_probe] || {})
+            .merge(host['kubevirt_readiness_probe'] || {})
+      {
+        'tcpSocket' => { 'port' => vm_ssh_port(host) },
+        'initialDelaySeconds' => cfg[:initial_delay_seconds] || 30,
+        'periodSeconds' => cfg[:period_seconds] || 10,
+        'timeoutSeconds' => cfg[:timeout_seconds] || 3,
+        'failureThreshold' => cfg[:failure_threshold] || 60,
+        'successThreshold' => cfg[:success_threshold] || 1,
+      }
+    end
+
+    ##
     # Setup networking for the VM
     # @param [Host] host The host to setup networking for
     def setup_networking(host)
       network_mode = host['kubevirt_network_mode'] || 'port-forward'
-      # Allow the VM SSH port to be configured per-host or use default
-      vm_ssh_port = host['kubevirt_vm_ssh_port'] || @options[:kubevirt_vm_ssh_port] || 22
 
       case network_mode
       when 'port-forward'
-        setup_port_forward(host, vm_ssh_port)
+        setup_port_forward(host, vm_ssh_port(host))
       when 'nodeport'
         setup_nodeport(host)
       when 'multus'

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -828,8 +828,11 @@ module Beaker
     # @param [Host] host The host configuration
     # @return [Boolean]
     def readiness_probe_disabled?(host)
-      return host['kubevirt_readiness_probe_disabled'] if host.key?('kubevirt_readiness_probe_disabled')
-      return @options[:kubevirt_readiness_probe_disabled] if @options.key?(:kubevirt_readiness_probe_disabled)
+      host_val = host['kubevirt_readiness_probe_disabled']
+      return host_val unless host_val.nil?
+
+      opt_val = @options[:kubevirt_readiness_probe_disabled]
+      return opt_val unless opt_val.nil?
 
       (host['kubevirt_network_mode'] || 'port-forward') == 'multus'
     end

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -43,6 +43,13 @@ module Beaker
     # Values of BEAKER_destroy that indicate resources should be preserved
     BEAKER_DESTROY_PRESERVE_VALUES = %w[no never onpass].freeze
 
+    # VMI phases that indicate the VM will never reach Running.
+    VMI_TERMINAL_PHASES = %w[Failed Succeeded].freeze
+    # virt-launcher container waiting reasons we treat as fatal.
+    FATAL_CONTAINER_WAITING_REASONS = %w[CrashLoopBackOff ImagePullBackOff ErrImagePull].freeze
+    # virt-launcher container termination reasons we treat as fatal.
+    FATAL_CONTAINER_TERMINATED_REASONS = %w[OOMKilled Error ContainerCannotRun].freeze
+
     ##
     # Create a new instance of the KubeVirt hypervisor object
     #
@@ -702,15 +709,13 @@ module Beaker
 
             # Then check if the VM is running
             vmi = @kubevirt_helper.get_vmi(vm_name)
-            phase = vmi && vmi.dig('status', 'phase')
+            phase = vmi&.dig('status', 'phase')
             if phase == 'Running'
               @logger.debug("VM #{vm_name} is running")
               break
             end
 
-            if %w[Failed Succeeded].include?(phase)
-              raise "VMI #{vm_name} entered terminal phase #{phase} before becoming Ready"
-            end
+            raise "VMI #{vm_name} entered terminal phase #{phase} before becoming Ready" if VMI_TERMINAL_PHASES.include?(phase)
 
             check_virt_launcher_health!(vm_name)
 
@@ -740,16 +745,16 @@ module Beaker
       statuses.each do |cs|
         name = cs['name']
         waiting_reason = cs.dig('state', 'waiting', 'reason')
-        if %w[CrashLoopBackOff ImagePullBackOff ErrImagePull].include?(waiting_reason)
+        if FATAL_CONTAINER_WAITING_REASONS.include?(waiting_reason)
           raise "virt-launcher container #{name} for #{vm_name} is #{waiting_reason}: " \
                 "#{cs.dig('state', 'waiting', 'message')}"
         end
 
         last_term = cs.dig('lastState', 'terminated') || cs.dig('state', 'terminated')
         reason = last_term && last_term['reason']
-        next unless %w[OOMKilled Error ContainerCannotRun].include?(reason)
+        next unless FATAL_CONTAINER_TERMINATED_REASONS.include?(reason)
 
-        hint = reason == 'OOMKilled' && name == 'compute' ? ' — increase :kubevirt_memory_overhead (default 512Mi)' : ''
+        hint = (reason == 'OOMKilled' && name == 'compute') ? ' — increase :kubevirt_memory_overhead (default 512Mi)' : ''
         raise "virt-launcher container #{name} for #{vm_name} terminated: #{reason}#{hint}"
       end
     end

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -58,6 +58,11 @@ module Beaker
     # @option options [String] :kubevirt_ssh_key SSH public key to inject
     # @option options [String] :kubevirt_cpus CPU resources for VM
     # @option options [String] :kubevirt_memory Memory resources for VM
+    # @option options [String] :kubevirt_memory_overhead Extra memory added to guest for the
+    #   container memory limit (default: '512Mi'). Needed for Windows guests where KubeVirt's
+    #   auto-computed virt-launcher overhead is too small and the compute container gets OOMKilled.
+    # @option options [String] :kubevirt_memory_request Memory request for the VM pod
+    #   (default: same as :kubevirt_memory).
     # @option options [Integer] :kubevirt_vm_ssh_port Port that SSH runs on inside the VM (default: 22)
     # @option options [Integer] :timeout Timeout for operations
     # @option options [Boolean] :kubevirt_disable_virtio Disable virtio devices (for compatibility with Windows)
@@ -459,6 +464,13 @@ module Beaker
       memory = host['kubevirt_memory'] || @options[:kubevirt_memory] || '2Gi'
       # If the memory is a plain number, assume MiB
       memory = "#{memory}Mi" if /^\d+$/.match?(memory)
+
+      overhead = host['kubevirt_memory_overhead'] || @options[:kubevirt_memory_overhead] || '512Mi'
+      overhead = "#{overhead}Mi" if /\A\d+\z/.match?(overhead.to_s)
+      memory_request = host['kubevirt_memory_request'] || @options[:kubevirt_memory_request] || memory
+      memory_request = "#{memory_request}Mi" if /\A\d+\z/.match?(memory_request.to_s)
+      memory_limit = "#{parse_memory_mib(memory) + parse_memory_mib(overhead)}Mi"
+
       vm_image = host['kubevirt_vm_image'] || @options[:kubevirt_vm_image]
       host_name = host.respond_to?(:name) ? host.name : host['name']
 
@@ -494,6 +506,10 @@ module Beaker
                 },
                 'memory' => {
                   'guest' => memory.to_s,
+                },
+                'resources' => {
+                  'requests' => { 'memory' => memory_request },
+                  'limits' => { 'memory' => memory_limit },
                 },
                 'devices' => generate_hardware_spec(host),
                 'features' => {
@@ -668,7 +684,6 @@ module Beaker
       timeout = @options[:timeout] || 300
       begin
         Timeout.timeout(timeout) do
-          # Wait for the VM to be created and running
           loop do
             # First, wait for the VM to exist
             vm = @kubevirt_helper.get_vm(vm_name)
@@ -687,16 +702,55 @@ module Beaker
 
             # Then check if the VM is running
             vmi = @kubevirt_helper.get_vmi(vm_name)
-            if vmi && vmi.dig('status', 'phase') == 'Running'
+            phase = vmi && vmi.dig('status', 'phase')
+            if phase == 'Running'
               @logger.debug("VM #{vm_name} is running")
               break
             end
+
+            if %w[Failed Succeeded].include?(phase)
+              raise "VMI #{vm_name} entered terminal phase #{phase} before becoming Ready"
+            end
+
+            check_virt_launcher_health!(vm_name)
+
             sleep SLEEPWAIT
           end
         end
       rescue Timeout::Error
         @logger.error("Timeout waiting for VM #{vm_name} to be ready")
         raise
+      end
+    end
+
+    ##
+    # Inspect the virt-launcher pod backing a VMI and raise with a specific reason
+    # if it has already failed (OOMKilled, image pull errors, crash loops, etc.)
+    # so we fail fast instead of waiting the full timeout.
+    # @param [String] vm_name
+    def check_virt_launcher_health!(vm_name)
+      pod = @kubevirt_helper.get_virt_launcher_pod(vm_name)
+      return unless pod
+
+      phase = pod.dig('status', 'phase')
+      raise "virt-launcher pod for #{vm_name} entered phase #{phase}" if phase == 'Failed'
+
+      statuses = Array(pod.dig('status', 'containerStatuses')) +
+                 Array(pod.dig('status', 'initContainerStatuses'))
+      statuses.each do |cs|
+        name = cs['name']
+        waiting_reason = cs.dig('state', 'waiting', 'reason')
+        if %w[CrashLoopBackOff ImagePullBackOff ErrImagePull].include?(waiting_reason)
+          raise "virt-launcher container #{name} for #{vm_name} is #{waiting_reason}: " \
+                "#{cs.dig('state', 'waiting', 'message')}"
+        end
+
+        last_term = cs.dig('lastState', 'terminated') || cs.dig('state', 'terminated')
+        reason = last_term && last_term['reason']
+        next unless %w[OOMKilled Error ContainerCannotRun].include?(reason)
+
+        hint = reason == 'OOMKilled' && name == 'compute' ? ' — increase :kubevirt_memory_overhead (default 512Mi)' : ''
+        raise "virt-launcher container #{name} for #{vm_name} terminated: #{reason}#{hint}"
       end
     end
 
@@ -854,6 +908,20 @@ module Beaker
     # - Maximum length of 63 characters
     # @param [String] name The string to sanitize
     # @return [String] RFC 1035 compliant string
+    # Parse a memory string ("4Gi", "512Mi", "2048") into an integer number of MiB.
+    # @param [String, Integer] value
+    # @return [Integer] MiB
+    def parse_memory_mib(value)
+      s = value.to_s.strip
+      case s
+      when /\A(\d+)Gi\z/ then Regexp.last_match(1).to_i * 1024
+      when /\A(\d+)Mi\z/ then Regexp.last_match(1).to_i
+      when /\A(\d+)\z/   then s.to_i
+      else
+        raise ArgumentError, "Cannot parse memory value #{value.inspect} (expected Gi/Mi suffix or bare MiB)"
+      end
+    end
+
     def sanitize_k8s_name(name)
       # Remove invalid characters, replace with hyphens
       sanitized = name.downcase.gsub(/[^a-z0-9-]/, '-')

--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -76,6 +76,28 @@ module Beaker
     end
 
     ##
+    # Get the virt-launcher pod backing a VMI.
+    # @param [String] vmi_name The VMI name (== VM name)
+    # @return [Hash, nil] pod object, or nil if not yet scheduled
+    def get_virt_launcher_pod(vmi_name)
+      pods = @k8s_client.get_pods(namespace: @namespace,
+                                  label_selector: "kubevirt.io/vm=#{vmi_name}")
+      pods.first
+    rescue Kubeclient::ResourceNotFoundError
+      nil
+    end
+
+    ##
+    # Delete a virtual machine
+    # @param [String] vm_name The VM name
+    def delete_vm(vm_name)
+      @kubevirt_client.delete_virtual_machine(vm_name, @namespace)
+      @logger.debug("Deleted VM #{vm_name}")
+    rescue Kubeclient::ResourceNotFoundError
+      @logger.debug("VM #{vm_name} not found during deletion")
+    end
+
+    ##
     # Cleanup VMs created by this test group
     # @param [String] test_group_identifier The identifier for the test group
     def cleanup_vms(test_group_identifier)

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -293,18 +293,91 @@ RSpec.describe Beaker::Kubevirt do
         expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'requests', 'memory')).to eq('2Gi')
       end
     end
+
+    context 'with the SSH readinessProbe' do
+      let(:probe) { vm_spec.dig('spec', 'template', 'spec', 'readinessProbe') }
+
+      it 'emits a tcpSocket probe on port 22 by default' do
+        expect(probe).to include(
+          'tcpSocket' => { 'port' => 22 },
+          'initialDelaySeconds' => 30,
+          'periodSeconds' => 10,
+          'timeoutSeconds' => 3,
+          'failureThreshold' => 60,
+          'successThreshold' => 1,
+        )
+      end
+
+      it 'uses the configured kubevirt_vm_ssh_port' do
+        hosts[0]['kubevirt_vm_ssh_port'] = 2222
+        expect(probe.dig('tcpSocket', 'port')).to eq(2222)
+      end
+
+      it 'omits the probe entirely when the host uses multus networking' do
+        hosts[0]['kubevirt_network_mode'] = 'multus'
+        expect(vm_spec.dig('spec', 'template', 'spec')).not_to have_key('readinessProbe')
+      end
+
+      it 'can be force-enabled under multus via opt-in' do
+        hosts[0]['kubevirt_network_mode'] = 'multus'
+        hosts[0]['kubevirt_readiness_probe_disabled'] = false
+        expect(probe).not_to be_nil
+      end
+
+      it 'can be disabled explicitly via options' do
+        options[:kubevirt_readiness_probe_disabled] = true
+        expect(vm_spec.dig('spec', 'template', 'spec')).not_to have_key('readinessProbe')
+      end
+
+      it 'merges caller overrides over defaults' do
+        options[:kubevirt_readiness_probe] = { period_seconds: 5, failure_threshold: 120 }
+        expect(probe).to include('periodSeconds' => 5, 'failureThreshold' => 120,
+                                 'initialDelaySeconds' => 30)
+      end
+
+      it 'prefers per-host readiness_probe overrides over global options' do
+        options[:kubevirt_readiness_probe] = { period_seconds: 5 }
+        hosts[0]['kubevirt_readiness_probe'] = { period_seconds: 15 }
+        expect(probe['periodSeconds']).to eq(15)
+      end
+    end
   end
 
   describe '#wait_for_vm_ready' do
     let(:hypervisor) { described_class.new(hosts, options.merge(timeout: 600)) }
     let(:host) { { 'vm_name' => 'test-vm' } }
+    let(:vm_object) { { 'metadata' => { 'name' => 'test-vm' } } }
+    let(:ready_true) { { 'type' => 'Ready', 'status' => 'True' } }
+    let(:ready_false) { { 'type' => 'Ready', 'status' => 'False', 'reason' => 'GuestNotRunning' } }
 
     before do
       stub_const('Beaker::Kubevirt::SLEEPWAIT', 0)
+      allow(kubevirt_helper).to receive_messages(get_vm: vm_object, get_virt_launcher_pod: nil)
     end
 
-    it 'returns when the VMI reaches Running' do
-      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Running' } })
+    it 'returns when the VMI is Running and Ready=True' do
+      allow(kubevirt_helper).to receive(:get_vmi)
+        .and_return('status' => { 'phase' => 'Running', 'conditions' => [ready_true] })
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+    end
+
+    it 'keeps waiting when phase is Running but Ready=False, then returns when Ready flips' do
+      not_ready = { 'status' => { 'phase' => 'Running', 'conditions' => [ready_false] } }
+      ready = { 'status' => { 'phase' => 'Running', 'conditions' => [ready_true] } }
+      allow(kubevirt_helper).to receive(:get_vmi).and_return(not_ready, not_ready, ready)
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+      expect(kubevirt_helper).to have_received(:get_vmi).at_least(3).times
+    end
+
+    it 'returns on phase=Running alone when the probe is disabled' do
+      host['kubevirt_readiness_probe_disabled'] = true
+      allow(kubevirt_helper).to receive(:get_vmi).and_return('status' => { 'phase' => 'Running' })
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+    end
+
+    it 'returns on phase=Running alone in multus mode (probe skipped by default)' do
+      host['kubevirt_network_mode'] = 'multus'
+      allow(kubevirt_helper).to receive(:get_vmi).and_return('status' => { 'phase' => 'Running' })
       expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
     end
 
@@ -350,6 +423,26 @@ RSpec.describe Beaker::Kubevirt do
       allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Failed' } })
       expect { hypervisor.send(:wait_for_vm_ready, host) }
         .to raise_error(/terminal phase Failed/)
+    end
+
+    describe 'effective timeout' do
+      it 'auto-raises the outer timeout to fit the probe budget' do
+        hypervisor = described_class.new(hosts, options.merge(timeout: 5))
+        # Tight probe budget: 0 + 0 * 3 + 60 = 60 > 5
+        host['kubevirt_readiness_probe'] = { initial_delay_seconds: 0, period_seconds: 0, failure_threshold: 3 }
+        expect(Timeout).to receive(:timeout).with(60).and_call_original
+        allow(kubevirt_helper).to receive(:get_vmi)
+          .and_return('status' => { 'phase' => 'Running', 'conditions' => [ready_true] })
+        hypervisor.send(:wait_for_vm_ready, host)
+      end
+
+      it 'keeps the configured timeout when the probe is disabled' do
+        hypervisor = described_class.new(hosts, options.merge(timeout: 42))
+        host['kubevirt_readiness_probe_disabled'] = true
+        expect(Timeout).to receive(:timeout).with(42).and_call_original
+        allow(kubevirt_helper).to receive(:get_vmi).and_return('status' => { 'phase' => 'Running' })
+        hypervisor.send(:wait_for_vm_ready, host)
+      end
     end
   end
 
@@ -1106,15 +1199,23 @@ RSpec.describe Beaker::Kubevirt do
     end
   end
 
-  describe '#wait_for_vm_ready' do
+  describe '#wait_for_vm_ready (legacy: VM existence polling)' do
     let(:vm_name) { 'beaker-abc123-test-host' }
     let(:hypervisor) { described_class.new(hosts, options.merge(timeout: 5)) }
     let(:host) { hosts[0].merge('vm_name' => vm_name) }
     let(:vm_object) { { 'metadata' => { 'name' => vm_name } } }
-    let(:running_vmi) { { 'status' => { 'phase' => 'Running' } } }
+    let(:running_vmi) do
+      {
+        'status' => {
+          'phase' => 'Running',
+          'conditions' => [{ 'type' => 'Ready', 'status' => 'True' }],
+        },
+      }
+    end
 
     before do
       allow(hypervisor).to receive(:sleep)
+      allow(kubevirt_helper).to receive(:get_virt_launcher_pod).and_return(nil)
     end
 
     context 'when VM eventually exists and remains available' do
@@ -1123,7 +1224,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:get_vmi).with(vm_name).and_return(nil, running_vmi)
       end
 
-      it 'waits until the VMI is running' do
+      it 'waits until the VMI is running and Ready' do
         expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
         expect(kubevirt_helper).to have_received(:get_vm).with(vm_name).at_least(:twice)
         expect(kubevirt_helper).to have_received(:get_vmi).with(vm_name).at_least(:once)

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -258,6 +258,100 @@ RSpec.describe Beaker::Kubevirt do
       cloud_init_volume = volumes.find { |v| v['name'] == 'cidata' }
       expect(cloud_init_volume.dig('cloudInitNoCloud', 'secretRef', 'name')).to eq(vm_spec_args[:cloud_init_data])
     end
+
+    context 'resource requests/limits' do
+      let(:options) do
+        {
+          logger: instance_double(Logger).as_null_object,
+          kubeconfig: '/tmp/kubeconfig',
+          namespace: 'beaker-test',
+          kubevirt_vm_image: 'docker://example/img',
+          kubevirt_memory: '4Gi',
+        }
+      end
+
+      it 'sets memory limit to guest plus default 512Mi overhead' do
+        expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'limits', 'memory')).to eq('4608Mi')
+      end
+
+      it 'defaults memory request to the guest value' do
+        expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'requests', 'memory')).to eq('4Gi')
+      end
+
+      it 'respects an overridden kubevirt_memory_overhead' do
+        options[:kubevirt_memory_overhead] = '1Gi'
+        expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'limits', 'memory')).to eq('5120Mi')
+      end
+
+      it 'respects a per-host kubevirt_memory_overhead' do
+        hosts[0]['kubevirt_memory_overhead'] = '256Mi'
+        expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'limits', 'memory')).to eq('4352Mi')
+      end
+
+      it 'respects an overridden kubevirt_memory_request' do
+        options[:kubevirt_memory_request] = '2Gi'
+        expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'requests', 'memory')).to eq('2Gi')
+      end
+    end
+
+  end
+
+  describe '#wait_for_vm_ready' do
+    let(:hypervisor) { described_class.new(hosts, options.merge(timeout: 600)) }
+    let(:host) { { 'vm_name' => 'test-vm' } }
+
+    before do
+      stub_const('Beaker::Kubevirt::SLEEPWAIT', 0)
+    end
+
+    it 'returns when the VMI reaches Running' do
+      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Running' } })
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+    end
+
+    it 'raises immediately when the compute container was OOMKilled' do
+      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Scheduling' } })
+      allow(kubevirt_helper).to receive(:get_virt_launcher_pod).and_return(
+        {
+          'status' => {
+            'phase' => 'Running',
+            'containerStatuses' => [
+              {
+                'name' => 'compute',
+                'lastState' => { 'terminated' => { 'reason' => 'OOMKilled', 'exitCode' => 137 } },
+                'state' => { 'waiting' => { 'reason' => 'CrashLoopBackOff' } },
+              },
+            ],
+          },
+        },
+      )
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.to raise_error(/CrashLoopBackOff|OOMKilled/)
+    end
+
+    it 'surfaces OOMKilled with an overhead hint when the container is not yet waiting' do
+      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Scheduling' } })
+      allow(kubevirt_helper).to receive(:get_virt_launcher_pod).and_return(
+        {
+          'status' => {
+            'phase' => 'Running',
+            'containerStatuses' => [
+              {
+                'name' => 'compute',
+                'state' => { 'terminated' => { 'reason' => 'OOMKilled', 'exitCode' => 137 } },
+              },
+            ],
+          },
+        },
+      )
+      expect { hypervisor.send(:wait_for_vm_ready, host) }
+        .to raise_error(/OOMKilled.*kubevirt_memory_overhead/)
+    end
+
+    it 'raises when the VMI reaches a terminal phase' do
+      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Failed' } })
+      expect { hypervisor.send(:wait_for_vm_ready, host) }
+        .to raise_error(/terminal phase Failed/)
+    end
   end
 
   describe '#generate_cloud_init' do

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Beaker::Kubevirt do
       expect(cloud_init_volume.dig('cloudInitNoCloud', 'secretRef', 'name')).to eq(vm_spec_args[:cloud_init_data])
     end
 
-    context 'resource requests/limits' do
+    context 'with explicit resource requests/limits' do
       let(:options) do
         {
           logger: instance_double(Logger).as_null_object,
@@ -293,7 +293,6 @@ RSpec.describe Beaker::Kubevirt do
         expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'requests', 'memory')).to eq('2Gi')
       end
     end
-
   end
 
   describe '#wait_for_vm_ready' do
@@ -310,9 +309,9 @@ RSpec.describe Beaker::Kubevirt do
     end
 
     it 'raises immediately when the compute container was OOMKilled' do
-      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Scheduling' } })
-      allow(kubevirt_helper).to receive(:get_virt_launcher_pod).and_return(
-        {
+      allow(kubevirt_helper).to receive_messages(
+        get_vmi: { 'status' => { 'phase' => 'Scheduling' } },
+        get_virt_launcher_pod: {
           'status' => {
             'phase' => 'Running',
             'containerStatuses' => [
@@ -329,9 +328,9 @@ RSpec.describe Beaker::Kubevirt do
     end
 
     it 'surfaces OOMKilled with an overhead hint when the container is not yet waiting' do
-      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Scheduling' } })
-      allow(kubevirt_helper).to receive(:get_virt_launcher_pod).and_return(
-        {
+      allow(kubevirt_helper).to receive_messages(
+        get_vmi: { 'status' => { 'phase' => 'Scheduling' } },
+        get_virt_launcher_pod: {
           'status' => {
             'phase' => 'Running',
             'containerStatuses' => [


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                         
  - Set `spec.template.spec.domain.resources` explicitly on the VM with a configurable                                                                                                                                                                                                                                   
    overhead (`kubevirt_memory_overhead`, default `512Mi`) and request                                                                                                                                                                                                                                                   
    (`kubevirt_memory_request`, defaults to guest). KubeVirt's mutating webhook only                                                                                                                                                                                                                                     
    fills `resources.limits.memory` when unset, so an explicit value is honored.                                                                                                                                                                                                                                         
    This re-adds the resources block previously removed in 2ef1d72, but now with                                                                                                                                                                                                                                         
    overhead configurable per host/run so Linux guests remain unaffected.                                                                                                                                                                                                                                                
  - Fail fast in `wait_for_vm_ready`: each poll, inspect the backing `virt-launcher`                                                                                                                                                                                                                                     
    pod and raise with a specific reason (`OOMKilled`, `CrashLoopBackOff`,                                                                                                                                                                                                                                               
    `ImagePullBackOff`, terminal VMI phase, ...) instead of hanging for the full                                                                                                                                                                                                                                         
    timeout. `OOMKilled` on the `compute` container includes a hint to raise                                                                                                                                                                                                                                             
    `kubevirt_memory_overhead`.                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                         
  ## Why                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                         
  Windows guests (4Gi, SMM + UEFI + virtio + pod-bridge) consistently hit                                                                                                                                                                                                                                                
  `OOMKilled` (exit 137) on the `virt-launcher` compute container because KubeVirt's                                                                                                                                                                                                                                     
  auto-computed overhead (~278Mi on a 4Gi guest) is tuned for Linux and too small                                                                                                                                                                                                                                        
  for QEMU's real RSS on Windows. Every failed Windows job sat in                                                                                                                                                                                                                                                        
  `wait_for_vm_ready` for the full 15 min before Beaker gave up with a generic                                                                                                                                                                                                                                           
  timeout, masking the real failure.                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                         
  - [x] `bundle exec rspec spec/beaker/kubevirt_spec.rb` — 194 examples, 0 failures.                                                                                                                                                                                                                                     
  - [  ] E2E: provision a 4Gi Windows guest against a real cluster; verify VMI reaches                                                                                                                                                                                                                                  
    `Running` and the virt-launcher compute container limit is `guest + overhead`.                                                                                                                                                                                                                                       
  - [  ] E2E fail-fast: set `kubevirt_memory_overhead: '0'`, confirm `wait_for_vm_ready`                                                                                                                                                                                                                                  
    raises within seconds with the `OOMKilled` message.