### PR TITLE
Add SSH readinessProbe so wait_for_vm_ready waits for sshd, not just …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wait_for_vm_ready` now inspects the virt-launcher pod each poll and fails
   fast with a specific reason (OOMKilled, CrashLoopBackOff, ImagePullBackOff,
   terminal VMI phase, ...) instead of hanging for the full timeout.
+- TCP `readinessProbe` on the guest's SSH port is added to the VM spec by
+  default (for `port-forward` and `nodeport` network modes; skipped for
+  `multus`). `wait_for_vm_ready` now waits for the VMI's `Ready` condition to
+  flip to `True`, so provisioning only hands off to Beaker once sshd is
+  actually accepting connections — no more SSH "connection refused" retries
+  while cloud-init / Windows first-boot is still running. Tunable via
+  `kubevirt_readiness_probe` and opt-out via `kubevirt_readiness_probe_disabled`.
+  When the probe is enabled, `timeout` is auto-raised to fit the probe's
+  failure budget.
 - Initial implementation of KubeVirt hypervisor provider for Beaker
 - Support for VM provisioning using KubeVirt VirtualMachine objects
 - Multiple image source support (PVC, ContainerDisk, DataVolume)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ CONFIG:
 | `kubevirt_disk_size` | Size of the root disk | No | `10Gi` | HOSTS (per-host) |
 | `kubevirt_cloud_init` | Custom cloud-init YAML | No | Auto-generated | HOSTS (per-host) |
 | `kubevirt_vm_ssh_port` | SSH port inside the VM | No | `22` | HOSTS (per-host) |
+| `kubevirt_readiness_probe_disabled` | Skip the VMI SSH readinessProbe. Default is `false` for pod-network modes and `true` for `multus` (where a probe from the virt-launcher netns typically can't reach a bridge-only guest). | No | mode-dependent | HOSTS (per-host), CONFIG |
+| `kubevirt_readiness_probe` | Probe tuning hash (snake_case keys): `initial_delay_seconds` (30), `period_seconds` (10), `timeout_seconds` (3), `failure_threshold` (60), `success_threshold` (1). The default failure budget (600s) accommodates slow Windows first-boots. When the probe is enabled, `timeout` is auto-raised to cover this budget. | No | see description | HOSTS (per-host), CONFIG |
 | `kubevirt_disable_virtio` | Disable virtio devices (for Windows compatibility). If set to true the disk bus will be set to `sata` and the network adapter will be model `e1000` | No | `false` | HOSTS (per-host) |
 
 **Important**: The `namespace`, `kubeconfig`, and `kubecontext` options must be specified in the global `CONFIG` section, not per-host. All VMs will be created in the same Kubernetes namespace.

--- a/examples/hosts.yaml
+++ b/examples/hosts.yaml
@@ -13,6 +13,12 @@ HOSTS:
     # limit. Bump this for Windows guests that get OOMKilled with the default.
     kubevirt_memory_overhead: 512Mi
     # kubevirt_memory_request: 4Gi   # defaults to kubevirt_memory
+    # Optional: tune the SSH readinessProbe (KubeVirt runs this from virt-launcher,
+    # flips the VMI Ready condition to True once sshd is accepting connections).
+    # kubevirt_readiness_probe:
+    #   initial_delay_seconds: 30
+    #   period_seconds: 10
+    #   failure_threshold: 120   # 120 * 10s = 20 min, for very slow Windows first-boots
     # Beaker-specific configuration
     user: centos
     ssh:

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -71,7 +71,16 @@ module Beaker
     # @option options [String] :kubevirt_memory_request Memory request for the VM pod
     #   (default: same as :kubevirt_memory).
     # @option options [Integer] :kubevirt_vm_ssh_port Port that SSH runs on inside the VM (default: 22)
-    # @option options [Integer] :timeout Timeout for operations
+    # @option options [Boolean] :kubevirt_readiness_probe_disabled Skip the VMI SSH
+    #   readinessProbe. Defaults to false for pod-network modes (port-forward, nodeport)
+    #   and true for multus (the tcpSocket probe runs from the virt-launcher pod's
+    #   network namespace and typically can't reach a bridge-only guest on a secondary NIC).
+    # @option options [Hash] :kubevirt_readiness_probe Probe tuning (all optional, snake_case):
+    #   :initial_delay_seconds (30), :period_seconds (10), :timeout_seconds (3),
+    #   :failure_threshold (60), :success_threshold (1). The default failure budget
+    #   (period_seconds * failure_threshold = 600s) accommodates slow Windows first-boots.
+    # @option options [Integer] :timeout Timeout for operations. When the readiness probe is
+    #   enabled, the effective wait is max(:timeout, probe budget + 60s).
     # @option options [Boolean] :kubevirt_disable_virtio Disable virtio devices (for compatibility with Windows)
     def initialize(kubevirt_hosts, options)
       require 'beaker/hypervisor/kubevirt_helper'
@@ -529,6 +538,7 @@ module Beaker
               },
               'hostname' => host_name,
               'networks' => generate_networks_spec(host),
+              'readinessProbe' => generate_readiness_probe_spec(host),
               'volumes' => [
                 generate_root_volume_spec(vm_image, host),
                 {
@@ -541,7 +551,7 @@ module Beaker
                 },
                 generate_service_account_volume_spec,
               ].compact,
-            },
+            }.compact,
           },
         },
       }
@@ -682,7 +692,9 @@ module Beaker
       vm_name = host['vm_name']
       @logger.info("Waiting for VM #{vm_name} to be ready...")
 
-      timeout = @options[:timeout] || 300
+      probe = generate_readiness_probe_spec(host)
+      timeout = effective_ready_timeout(probe)
+
       begin
         Timeout.timeout(timeout) do
           loop do
@@ -704,8 +716,9 @@ module Beaker
             # Then check if the VM is running
             vmi = @kubevirt_helper.get_vmi(vm_name)
             phase = vmi&.dig('status', 'phase')
-            if phase == 'Running'
-              @logger.debug("VM #{vm_name} is running")
+
+            if phase == 'Running' && vmi_ssh_ready?(vmi, probe)
+              @logger.debug("VM #{vm_name} is ready")
               break
             end
 
@@ -720,6 +733,45 @@ module Beaker
         @logger.error("Timeout waiting for VM #{vm_name} to be ready")
         raise
       end
+    end
+
+    ##
+    # Whether the VMI is fully ready. If a readiness probe is configured,
+    # require the KubeVirt-managed `Ready` status condition to be True (that
+    # tracks the tcpSocket probe, so sshd is actually listening). Otherwise
+    # fall back to phase=Running alone — the historical behavior.
+    # @param [Hash] vmi VMI object from the kubevirt API
+    # @param [Hash, nil] probe The probe spec, or nil when disabled
+    # @return [Boolean]
+    def vmi_ssh_ready?(vmi, probe)
+      return true if probe.nil?
+
+      condition = Array(vmi&.dig('status', 'conditions'))
+                  .find { |c| c['type'] == 'Ready' }
+      if condition.nil?
+        @logger.debug('VMI has no Ready condition yet, continuing to wait')
+        return false
+      end
+      return true if condition['status'] == 'True'
+
+      @logger.debug("VMI Ready=#{condition['status']} reason=#{condition['reason']} message=#{condition['message']}")
+      false
+    end
+
+    ##
+    # Compute the effective outer Timeout for wait_for_vm_ready. When a probe
+    # is configured, the probe's worst-case budget (initial delay + period *
+    # failureThreshold) must fit, otherwise a user who left :timeout at the
+    # default would see the probe truncated before it can fail legitimately.
+    # @param [Hash, nil] probe
+    # @return [Integer] seconds
+    def effective_ready_timeout(probe)
+      base = @options[:timeout] || 300
+      return base if probe.nil?
+
+      probe_budget = probe['initialDelaySeconds'] +
+                     (probe['periodSeconds'] * probe['failureThreshold']) + 60
+      [base, probe_budget].max
     end
 
     ##
@@ -754,16 +806,61 @@ module Beaker
     end
 
     ##
+    # The guest-side port SSH listens on, shared between the VMI readiness probe
+    # and client-side networking setup so they can never drift apart.
+    # @param [Host] host The host configuration
+    # @return [Integer] SSH port inside the guest
+    def vm_ssh_port(host)
+      host['kubevirt_vm_ssh_port'] || @options[:kubevirt_vm_ssh_port] || 22
+    end
+
+    ##
+    # Whether the SSH readinessProbe should be skipped for this host.
+    # Defaults to false for pod-network modes (port-forward, nodeport) and true
+    # for multus (the probe runs from the virt-launcher pod's netns and
+    # typically can't reach a bridge-only guest on a secondary interface).
+    # @param [Host] host The host configuration
+    # @return [Boolean]
+    def readiness_probe_disabled?(host)
+      return host['kubevirt_readiness_probe_disabled'] if host.key?('kubevirt_readiness_probe_disabled')
+      return @options[:kubevirt_readiness_probe_disabled] if @options.key?(:kubevirt_readiness_probe_disabled)
+
+      (host['kubevirt_network_mode'] || 'port-forward') == 'multus'
+    end
+
+    ##
+    # Build the KubeVirt readinessProbe hash for a host, or nil if disabled.
+    # A tcpSocket probe on the guest's SSH port lets KubeVirt publish a
+    # Ready condition once sshd is actually accepting connections — wait_for_vm_ready
+    # gates on that condition so Beaker doesn't attempt SSH before the guest is up.
+    # Per-host overrides win over global options; snake_case keys map to the
+    # camelCase probe fields KubeVirt expects.
+    # @param [Host] host The host configuration
+    # @return [Hash, nil]
+    def generate_readiness_probe_spec(host)
+      return nil if readiness_probe_disabled?(host)
+
+      cfg = (@options[:kubevirt_readiness_probe] || {})
+            .merge(host['kubevirt_readiness_probe'] || {})
+      {
+        'tcpSocket' => { 'port' => vm_ssh_port(host) },
+        'initialDelaySeconds' => cfg[:initial_delay_seconds] || 30,
+        'periodSeconds' => cfg[:period_seconds] || 10,
+        'timeoutSeconds' => cfg[:timeout_seconds] || 3,
+        'failureThreshold' => cfg[:failure_threshold] || 60,
+        'successThreshold' => cfg[:success_threshold] || 1,
+      }
+    end
+
+    ##
     # Setup networking for the VM
     # @param [Host] host The host to setup networking for
     def setup_networking(host)
       network_mode = host['kubevirt_network_mode'] || 'port-forward'
-      # Allow the VM SSH port to be configured per-host or use default
-      vm_ssh_port = host['kubevirt_vm_ssh_port'] || @options[:kubevirt_vm_ssh_port] || 22
 
       case network_mode
       when 'port-forward'
-        setup_port_forward(host, vm_ssh_port)
+        setup_port_forward(host, vm_ssh_port(host))
       when 'nodeport'
         setup_nodeport(host)
       when 'multus'

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -293,18 +293,91 @@ RSpec.describe Beaker::Kubevirt do
         expect(vm_spec.dig('spec', 'template', 'spec', 'domain', 'resources', 'requests', 'memory')).to eq('2Gi')
       end
     end
+
+    context 'with the SSH readinessProbe' do
+      let(:probe) { vm_spec.dig('spec', 'template', 'spec', 'readinessProbe') }
+
+      it 'emits a tcpSocket probe on port 22 by default' do
+        expect(probe).to include(
+          'tcpSocket' => { 'port' => 22 },
+          'initialDelaySeconds' => 30,
+          'periodSeconds' => 10,
+          'timeoutSeconds' => 3,
+          'failureThreshold' => 60,
+          'successThreshold' => 1,
+        )
+      end
+
+      it 'uses the configured kubevirt_vm_ssh_port' do
+        hosts[0]['kubevirt_vm_ssh_port'] = 2222
+        expect(probe.dig('tcpSocket', 'port')).to eq(2222)
+      end
+
+      it 'omits the probe entirely when the host uses multus networking' do
+        hosts[0]['kubevirt_network_mode'] = 'multus'
+        expect(vm_spec.dig('spec', 'template', 'spec')).not_to have_key('readinessProbe')
+      end
+
+      it 'can be force-enabled under multus via opt-in' do
+        hosts[0]['kubevirt_network_mode'] = 'multus'
+        hosts[0]['kubevirt_readiness_probe_disabled'] = false
+        expect(probe).not_to be_nil
+      end
+
+      it 'can be disabled explicitly via options' do
+        options[:kubevirt_readiness_probe_disabled] = true
+        expect(vm_spec.dig('spec', 'template', 'spec')).not_to have_key('readinessProbe')
+      end
+
+      it 'merges caller overrides over defaults' do
+        options[:kubevirt_readiness_probe] = { period_seconds: 5, failure_threshold: 120 }
+        expect(probe).to include('periodSeconds' => 5, 'failureThreshold' => 120,
+                                 'initialDelaySeconds' => 30)
+      end
+
+      it 'prefers per-host readiness_probe overrides over global options' do
+        options[:kubevirt_readiness_probe] = { period_seconds: 5 }
+        hosts[0]['kubevirt_readiness_probe'] = { period_seconds: 15 }
+        expect(probe['periodSeconds']).to eq(15)
+      end
+    end
   end
 
   describe '#wait_for_vm_ready' do
     let(:hypervisor) { described_class.new(hosts, options.merge(timeout: 600)) }
     let(:host) { { 'vm_name' => 'test-vm' } }
+    let(:vm_object) { { 'metadata' => { 'name' => 'test-vm' } } }
+    let(:ready_true) { { 'type' => 'Ready', 'status' => 'True' } }
+    let(:ready_false) { { 'type' => 'Ready', 'status' => 'False', 'reason' => 'GuestNotRunning' } }
 
     before do
       stub_const('Beaker::Kubevirt::SLEEPWAIT', 0)
+      allow(kubevirt_helper).to receive_messages(get_vm: vm_object, get_virt_launcher_pod: nil)
     end
 
-    it 'returns when the VMI reaches Running' do
-      allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Running' } })
+    it 'returns when the VMI is Running and Ready=True' do
+      allow(kubevirt_helper).to receive(:get_vmi)
+        .and_return('status' => { 'phase' => 'Running', 'conditions' => [ready_true] })
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+    end
+
+    it 'keeps waiting when phase is Running but Ready=False, then returns when Ready flips' do
+      not_ready = { 'status' => { 'phase' => 'Running', 'conditions' => [ready_false] } }
+      ready = { 'status' => { 'phase' => 'Running', 'conditions' => [ready_true] } }
+      allow(kubevirt_helper).to receive(:get_vmi).and_return(not_ready, not_ready, ready)
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+      expect(kubevirt_helper).to have_received(:get_vmi).at_least(3).times
+    end
+
+    it 'returns on phase=Running alone when the probe is disabled' do
+      host['kubevirt_readiness_probe_disabled'] = true
+      allow(kubevirt_helper).to receive(:get_vmi).and_return('status' => { 'phase' => 'Running' })
+      expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
+    end
+
+    it 'returns on phase=Running alone in multus mode (probe skipped by default)' do
+      host['kubevirt_network_mode'] = 'multus'
+      allow(kubevirt_helper).to receive(:get_vmi).and_return('status' => { 'phase' => 'Running' })
       expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
     end
 
@@ -350,6 +423,26 @@ RSpec.describe Beaker::Kubevirt do
       allow(kubevirt_helper).to receive(:get_vmi).and_return({ 'status' => { 'phase' => 'Failed' } })
       expect { hypervisor.send(:wait_for_vm_ready, host) }
         .to raise_error(/terminal phase Failed/)
+    end
+
+    describe 'effective timeout' do
+      it 'auto-raises the outer timeout to fit the probe budget' do
+        hypervisor = described_class.new(hosts, options.merge(timeout: 5))
+        # Tight probe budget: 0 + 0 * 3 + 60 = 60 > 5
+        host['kubevirt_readiness_probe'] = { initial_delay_seconds: 0, period_seconds: 0, failure_threshold: 3 }
+        expect(Timeout).to receive(:timeout).with(60).and_call_original
+        allow(kubevirt_helper).to receive(:get_vmi)
+          .and_return('status' => { 'phase' => 'Running', 'conditions' => [ready_true] })
+        hypervisor.send(:wait_for_vm_ready, host)
+      end
+
+      it 'keeps the configured timeout when the probe is disabled' do
+        hypervisor = described_class.new(hosts, options.merge(timeout: 42))
+        host['kubevirt_readiness_probe_disabled'] = true
+        expect(Timeout).to receive(:timeout).with(42).and_call_original
+        allow(kubevirt_helper).to receive(:get_vmi).and_return('status' => { 'phase' => 'Running' })
+        hypervisor.send(:wait_for_vm_ready, host)
+      end
     end
   end
 
@@ -1106,15 +1199,23 @@ RSpec.describe Beaker::Kubevirt do
     end
   end
 
-  describe '#wait_for_vm_ready' do
+  describe '#wait_for_vm_ready (legacy: VM existence polling)' do
     let(:vm_name) { 'beaker-abc123-test-host' }
     let(:hypervisor) { described_class.new(hosts, options.merge(timeout: 5)) }
     let(:host) { hosts[0].merge('vm_name' => vm_name) }
     let(:vm_object) { { 'metadata' => { 'name' => vm_name } } }
-    let(:running_vmi) { { 'status' => { 'phase' => 'Running' } } }
+    let(:running_vmi) do
+      {
+        'status' => {
+          'phase' => 'Running',
+          'conditions' => [{ 'type' => 'Ready', 'status' => 'True' }],
+        },
+      }
+    end
 
     before do
       allow(hypervisor).to receive(:sleep)
+      allow(kubevirt_helper).to receive(:get_virt_launcher_pod).and_return(nil)
     end
 
     context 'when VM eventually exists and remains available' do
@@ -1123,7 +1224,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:get_vmi).with(vm_name).and_return(nil, running_vmi)
       end
 
-      it 'waits until the VMI is running' do
+      it 'waits until the VMI is running and Ready' do
         expect { hypervisor.send(:wait_for_vm_ready, host) }.not_to raise_error
         expect(kubevirt_helper).to have_received(:get_vm).with(vm_name).at_least(:twice)
         expect(kubevirt_helper).to have_received(:get_vmi).with(vm_name).at_least(:once)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                         
  - Add a tcpSocket readinessProbe on the guest SSH port to the VM spec
    (default on for port-forward/nodeport; off for multus, opt-in available)                                                                                                         
  - `wait_for_vm_ready` now requires phase=Running AND the VMI Ready        
    condition to be True when the probe is configured, so provisioning                                                                                                             
    hands off only after sshd is actually accepting connections                                                                                                                    
  - Auto-raise the outer Timeout to fit the probe's failure budget so                                                                                                                
    users don't need to tune :timeout and probe settings in lockstep                                                                                                                 
  - Factor shared kubevirt_vm_ssh_port lookup into a helper so the probe                                                                                                             
    port and forwarded port can't drift apart                                                                                                                                        
  - Fix six pre-existing #wait_for_vm_ready specs that were missing                                                                                                                  
    get_vm / get_virt_launcher_pod stubs                                                                                                                                             
                                                                                                                                                                                     
  Stacked on #<OOM-PR>. Rebase to main after that lands.                                                                                                                             
                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                       
  - [x] `bundle exec rspec spec/beaker/kubevirt_spec.rb` — 208 examples, 0 failures                                                                                                
  - [x] `bundle exec rubocop` — clean across 15 files                                                                                                                                
  - [ ] Re-run Windows pipeline 196900 against this branch; confirm probe
        flips Ready condition to True and provisioning proceeds                                                                                                                      
  - [ ] Smoke a Linux port-forward host — no connection-refused retries                                                                                                            
  - [ ] Smoke a multus host — spec emits no readinessProbe; back-compat preserved