### PR TITLE
Fix NoMethodError: key? on Beaker::Host in readiness_probe_disabled?

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -124,6 +124,36 @@ The gem is ready for:
 - Community feedback and contributions
 - Enhancement based on user needs
 
+## Developer Gotchas
+
+### `Beaker::Host` does not support `key?`
+
+`Beaker::Host` (and subclasses like `PSWindows::Host`) proxy `[]` and `[]=`
+to an internal options hash but do **not** expose `key?`, `fetch`, `dig`, or
+other `Hash` methods. Calling them raises `NoMethodError` at runtime —
+silently passing unit specs that use plain `Hash` fixtures for hosts.
+
+Do not write:
+
+```ruby
+return host['foo'] if host.key?('foo')
+```
+
+Instead, treat `nil` as "unset" so both presence and an explicit `false`
+are preserved:
+
+```ruby
+val = host['foo']
+return val unless val.nil?
+```
+
+See `readiness_probe_disabled?` in `lib/beaker/hypervisor/kubevirt.rb` for
+the canonical pattern, and `vm_ssh_port` for the simpler `host['x'] || default`
+form when `false` isn't a meaningful value. When the distinction between
+"unset" and "explicitly false" matters for a new option, add an acceptance
+or integration-level test — unit tests with `Hash` fixtures will not catch
+the `key?` failure.
+
 ## Integration with Beaker Ecosystem
 
 This implementation follows established Beaker patterns (similar to beaker-google, beaker-aws, etc.) ensuring:

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -822,8 +822,11 @@ module Beaker
     # @param [Host] host The host configuration
     # @return [Boolean]
     def readiness_probe_disabled?(host)
-      return host['kubevirt_readiness_probe_disabled'] if host.key?('kubevirt_readiness_probe_disabled')
-      return @options[:kubevirt_readiness_probe_disabled] if @options.key?(:kubevirt_readiness_probe_disabled)
+      host_val = host['kubevirt_readiness_probe_disabled']
+      return host_val unless host_val.nil?
+
+      opt_val = @options[:kubevirt_readiness_probe_disabled]
+      return opt_val unless opt_val.nil?
 
       (host['kubevirt_network_mode'] || 'port-forward') == 'multus'
     end


### PR DESCRIPTION
- Beaker::Host (incl. PSWindows::Host) proxies []/[]= but not key?, so the new readinessProbe helper raised NoMethodError on every real run (sicura-nx job 891059). Unit specs passed because they use  plain Hash fixtures.
  - Swap host.key? / @options.key? for nil? checks in readiness_probe_disabled?, preserving the explicit-false opt-in under multus.
  - Document the gotcha in IMPLEMENTATION.md.