### PR TITLE
Log SSH private key basename at INFO, full path at DEBUG

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -969,7 +969,8 @@ module Beaker
         ssh_options['keys'] = [key_pair[:private_key_path]]
         host['ssh'] = ssh_options
 
-        @logger.info("Configured SSH to use private key: #{key_pair[:private_key_path]}")
+        @logger.info("Configured SSH to use private key #{File.basename(key_pair[:private_key_path])}")
+        @logger.debug("SSH private key full path: #{key_pair[:private_key_path]}")
       else
         @logger.warn('Could not determine private key path, SSH will use default keys')
       end


### PR DESCRIPTION
## Summary
- Demote the full SSH private-key path to DEBUG and log only the basename at INFO.
- Default-verbose logs no longer leak the operator's home directory / key filename; full path is still available with `--debug`.

## Test plan
- [x] `bundle exec rake` (spec + rubocop)