### PR TITLE
Scope at_exit cleanup suppression to this gem's own tests

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -105,8 +105,11 @@ module Beaker
       # provisioning but before normal cleanup
       # Note: Each instance registers its own at_exit handler, but cleanup is idempotent
       # and scoped to the specific test_group_identifier for this instance
-      # Skip registration during tests to avoid issues with mock objects
-      return if defined?(RSpec)
+      # Skip registration during this gem's own rspec run (set by spec_helper).
+      # Gating on `defined?(RSpec)` misfired in downstream projects that run
+      # Beaker from inside their own rspec suite, suppressing the safety net
+      # for every consumer.
+      return if ENV['BEAKER_KUBEVIRT_DISABLE_AT_EXIT_CLEANUP'] == '1'
 
       at_exit do
         cleanup_on_exit

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,11 @@ require 'simplecov'
 
 SimpleCov.start
 
+# Suppress Beaker::Kubevirt's at_exit cleanup handler during this gem's own
+# test run. In downstream projects (which may also have RSpec loaded) the
+# handler should remain active.
+ENV['BEAKER_KUBEVIRT_DISABLE_AT_EXIT_CLEANUP'] = '1'
+
 require 'beaker/hypervisor/kubevirt'
 require 'beaker/hypervisor/kubevirt_helper'
 


### PR DESCRIPTION
## Summary
- Replace the `defined?(RSpec)` check with an env var marker set in this gem's `spec_helper.rb`, so downstream projects that use Beaker from within their own rspec suite still get the at_exit cleanup safety net.

## Test plan
- [x] \`bundle exec rake\` — still passes; spec_helper sets the new env var.