### PR TITLE
Tag NodePort services with beaker/test-group for cleanup

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -960,7 +960,7 @@ module Beaker
       service_name = "#{vm_name}-ssh"
 
       @logger.debug("Creating NodePort service for VM #{vm_name}")
-      service = @kubevirt_helper.create_nodeport_service(vm_name, service_name)
+      service = @kubevirt_helper.create_nodeport_service(vm_name, service_name, @test_group_identifier)
 
       node_port = service.dig('spec', 'ports', 0, 'nodePort')
       node_ip = @kubevirt_helper.node_ip

--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -239,6 +239,9 @@ module Beaker
     # Create a NodePort service for SSH access
     # @param [String] vm_name The VM name
     # @param [String] service_name The service name
+    # @param [String, nil] test_group_identifier Test-group identifier applied as
+    #   the +beaker/test-group+ label so +cleanup_services+ can match the
+    #   service. When +nil+, only the +beaker/vm+ label is set (legacy behavior).
     # @return [Hash] Service object
     def create_nodeport_service(vm_name, service_name, test_group_identifier = nil)
       labels = { 'beaker/vm' => vm_name }

--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -240,16 +240,17 @@ module Beaker
     # @param [String] vm_name The VM name
     # @param [String] service_name The service name
     # @return [Hash] Service object
-    def create_nodeport_service(vm_name, service_name)
+    def create_nodeport_service(vm_name, service_name, test_group_identifier = nil)
+      labels = { 'beaker/vm' => vm_name }
+      labels['beaker/test-group'] = test_group_identifier if test_group_identifier
+
       service_spec = {
         'apiVersion' => 'v1',
         'kind' => 'Service',
         'metadata' => {
           'name' => service_name,
           'namespace' => @namespace,
-          'labels' => {
-            'beaker/vm' => vm_name,
-          },
+          'labels' => labels,
         },
         'spec' => {
           'type' => 'NodePort',

--- a/spec/beaker/kubevirt_helper_spec.rb
+++ b/spec/beaker/kubevirt_helper_spec.rb
@@ -220,6 +220,28 @@ RSpec.describe Beaker::KubevirtHelper do
     end
   end
 
+  describe '#create_nodeport_service' do
+    let(:k8s_client) { double('k8s_client') }
+    let(:opts) { options.merge(k8s_client: k8s_client) }
+    let(:helper) { described_class.new(opts) }
+
+    before do
+      allow(k8s_client).to receive(:create_service) { |spec| spec }
+    end
+
+    it 'tags the service with both beaker/vm and beaker/test-group labels' do
+      spec = helper.create_nodeport_service('my-vm', 'my-vm-ssh', 'beaker-abcd1234')
+      labels = spec.dig(:metadata, :labels)
+      expect(labels).to include('beaker/vm': 'my-vm', 'beaker/test-group': 'beaker-abcd1234')
+    end
+
+    it 'omits the test-group label when none is provided' do
+      spec = helper.create_nodeport_service('my-vm', 'my-vm-ssh')
+      labels = spec.dig(:metadata, :labels)
+      expect(labels).to eq('beaker/vm': 'my-vm')
+    end
+  end
+
   describe 'manual kubeconfig parsing fallback' do
     let(:clients) do
       {


### PR DESCRIPTION
## Summary
- Add \`beaker/test-group\` label to NodePort services at creation so \`cleanup_services\` (which selects by that label) actually matches them.
- Threads \`@test_group_identifier\` into \`create_nodeport_service\` as a third argument; left nil-safe so other callers don't break.

## Test plan
- [x] \`bundle exec rake\` — new specs assert both labels land on the service spec.
- [ ] Operator backfill for existing leaks: \`kubectl get svc -A -l beaker/vm -o name | xargs -r kubectl delete\`