### PR TITLE
Normalize and validate kubeconfig path

### DIFF
--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -13,7 +13,8 @@ module Beaker
     def initialize(options)
       @options = options
       @namespace = options[:namespace] || 'default'
-      @kubeconfig_path = options[:kubeconfig] || ENV['KUBECONFIG'] || File.join(Dir.home, '.kube', 'config')
+      raw_kubeconfig = options[:kubeconfig] || ENV['KUBECONFIG'] || File.join(Dir.home, '.kube', 'config')
+      @kubeconfig_path = File.expand_path(raw_kubeconfig)
       @kubecontext = options[:kubecontext] || ENV.fetch('KUBECONTEXT', nil)
       @logger = options[:logger]
 
@@ -374,6 +375,9 @@ module Beaker
     def load_kubeconfig
       return @kubeconfig_data if @kubeconfig_data
       raise "Kubeconfig file not found: #{@kubeconfig_path}" unless File.exist?(@kubeconfig_path)
+      raise "Kubeconfig path is not a regular file: #{@kubeconfig_path}" unless File.file?(@kubeconfig_path)
+
+      @logger&.warn("kubeconfig #{@kubeconfig_path} is a symlink to #{File.realpath(@kubeconfig_path)}") if File.symlink?(@kubeconfig_path)
 
       @kubeconfig_data = YAML.safe_load_file(@kubeconfig_path)
       @kubeconfig_data

--- a/spec/beaker/kubevirt_helper_spec.rb
+++ b/spec/beaker/kubevirt_helper_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe Beaker::KubevirtHelper do
 
       before do
         allow(File).to receive(:exist?).with('/tmp/test-kubeconfig').and_return(true)
+        allow(File).to receive(:file?).with('/tmp/test-kubeconfig').and_return(true)
+        allow(File).to receive(:symlink?).with('/tmp/test-kubeconfig').and_return(false)
         allow(YAML).to receive(:safe_load_file).with('/tmp/test-kubeconfig').and_return(mock_config)
         allow(Kubeclient::Client).to receive(:new).and_return(clients[:k8s], clients[:kubevirt])
       end
@@ -116,6 +118,8 @@ RSpec.describe Beaker::KubevirtHelper do
 
     before do
       allow(File).to receive(:exist?).with('/tmp/test-kubeconfig').and_return(true)
+      allow(File).to receive(:file?).with('/tmp/test-kubeconfig').and_return(true)
+      allow(File).to receive(:symlink?).with('/tmp/test-kubeconfig').and_return(false)
       allow(YAML).to receive(:safe_load_file).with('/tmp/test-kubeconfig').and_return(mock_config)
     end
 
@@ -234,6 +238,8 @@ RSpec.describe Beaker::KubevirtHelper do
 
     before do
       allow(File).to receive(:exist?).with('/tmp/test-kubeconfig').and_return(true)
+      allow(File).to receive(:file?).with('/tmp/test-kubeconfig').and_return(true)
+      allow(File).to receive(:symlink?).with('/tmp/test-kubeconfig').and_return(false)
       allow(YAML).to receive(:safe_load_file).with('/tmp/test-kubeconfig').and_return(mock_config)
       allow(Kubeclient::Config).to receive(:read).and_raise(RuntimeError, 'Unknown kubeconfig version')
       allow(Kubeclient::Client).to receive(:new).and_return(clients[:k8s], clients[:kubevirt])


### PR DESCRIPTION
## Summary
- \`File.expand_path\` the kubeconfig before use so relative / \`~\`-prefixed paths behave consistently.
- Reject non-regular files (directories, FIFOs, device files) up front.
- Warn when the resolved path is a symlink.

## Test plan
- [x] \`bundle exec rake\`