### PR TITLE
Sanitize hostnames before using as k8s label values

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -43,8 +43,10 @@ module Beaker
     # Values of BEAKER_destroy that indicate resources should be preserved
     BEAKER_DESTROY_PRESERVE_VALUES = %w[no never onpass].freeze
 
+    # Shared Kubernetes 63-character upper bound used by names/labels in this class.
+    K8S_NAME_MAX = 63
     # Kubernetes label-value upper bound (RFC 1123, 63 chars).
-    LABEL_VALUE_MAX = 63
+    LABEL_VALUE_MAX = K8S_NAME_MAX
 
     # VMI phases that indicate the VM will never reach Running.
     VMI_TERMINAL_PHASES = %w[Failed Succeeded].freeze

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -43,6 +43,9 @@ module Beaker
     # Values of BEAKER_destroy that indicate resources should be preserved
     BEAKER_DESTROY_PRESERVE_VALUES = %w[no never onpass].freeze
 
+    # Kubernetes label-value upper bound (RFC 1123, 63 chars).
+    LABEL_VALUE_MAX = 63
+
     # VMI phases that indicate the VM will never reach Running.
     VMI_TERMINAL_PHASES = %w[Failed Succeeded].freeze
     # virt-launcher container waiting reasons we treat as fatal.
@@ -412,10 +415,24 @@ module Beaker
     end
 
     def get_labels(host)
+      raw_name = host.respond_to?(:name) ? host.name : host['name']
       {
         'beaker/test-group' => @test_group_identifier,
-        'beaker/host' => host.respond_to?(:name) ? host.name : host['name'],
+        'beaker/host' => sanitize_k8s_label_value(raw_name),
       }
+    end
+
+    ##
+    # Sanitize a string to meet Kubernetes' label-value constraints
+    # (1..63 chars, [a-zA-Z0-9_.-], must start and end alphanumeric).
+    # Unlike sanitize_k8s_name this preserves dots, underscores, and case —
+    # labels allow them and losing that information makes `kubectl -l` lookups
+    # by hostname fail.
+    def sanitize_k8s_label_value(value)
+      cleaned = value.to_s.gsub(/[^-A-Za-z0-9_.]/, '-')
+      cleaned = cleaned[0, LABEL_VALUE_MAX]
+      cleaned = cleaned.sub(/\A[^A-Za-z0-9]+/, '').sub(/[^A-Za-z0-9]+\z/, '')
+      cleaned.empty? ? sanitize_k8s_name(value) : cleaned
     end
 
     def disk_bus(host)

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -45,7 +45,7 @@ module Beaker
 
     # Shared Kubernetes 63-character upper bound used by names/labels in this class.
     K8S_NAME_MAX = 63
-    # Kubernetes label-value upper bound (RFC 1123, 63 chars).
+    # Kubernetes label-value maximum length under Kubernetes label value constraints (63 chars).
     LABEL_VALUE_MAX = K8S_NAME_MAX
 
     # VMI phases that indicate the VM will never reach Running.

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -425,8 +425,10 @@ module Beaker
     end
 
     ##
-    # Sanitize a string to meet Kubernetes' label-value constraints
-    # (1..63 chars, [a-zA-Z0-9_.-], must start and end alphanumeric).
+    # Sanitize a string to meet Kubernetes' label-value constraints:
+    # label values may be empty; otherwise they may be up to 63 characters,
+    # contain only [a-zA-Z0-9_.-], and must start and end with an
+    # alphanumeric character.
     # Unlike sanitize_k8s_name this preserves dots, underscores, and case —
     # labels allow them and losing that information makes `kubectl -l` lookups
     # by hostname fail.

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -736,6 +736,38 @@ RSpec.describe Beaker::Kubevirt do
     end
   end
 
+  describe '#sanitize_k8s_label_value' do
+    let(:hypervisor) { described_class.new(hosts, options) }
+
+    it 'passes through a simple name' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, 'foo')).to eq('foo')
+    end
+
+    it 'preserves case, dots, and underscores' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, 'My.Host_01')).to eq('My.Host_01')
+    end
+
+    it 'replaces disallowed characters with hyphens' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, 'foo/bar')).to eq('foo-bar')
+    end
+
+    it 'strips leading non-alphanumeric characters' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, '-leading')).to eq('leading')
+    end
+
+    it 'strips trailing non-alphanumeric characters' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, 'trailing-')).to eq('trailing')
+    end
+
+    it 'caps length at 63 characters' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, 'a' * 100).length).to eq(63)
+    end
+
+    it 'falls back to sanitize_k8s_name when nothing alphanumeric remains' do
+      expect(hypervisor.send(:sanitize_k8s_label_value, '!!')).to eq(hypervisor.send(:sanitize_k8s_name, '!!'))
+    end
+  end
+
   describe '#generate_root_volume_dvtemplate' do
     let(:hypervisor) { described_class.new(hosts, options) }
     let(:vm_name) { 'test-vm-123' }
@@ -1438,6 +1470,11 @@ RSpec.describe Beaker::Kubevirt do
     it 'includes beaker/host label with host name' do
       result = hypervisor.send(:get_labels, host)
       expect(result['beaker/host']).to eq('test-host')
+    end
+
+    it 'sanitizes hostnames that are invalid as k8s label values' do
+      result = hypervisor.send(:get_labels, { 'name' => 'foo/bar' })
+      expect(result['beaker/host']).to eq('foo-bar')
     end
 
     it 'uses host name from name method when available' do


### PR DESCRIPTION
## Summary
- Run the \`beaker/host\` label value through \`sanitize_k8s_label_value\` so host names like \`foo/bar\` no longer cause apiserver rejection of the VM create, which previously left orphan secrets/services behind.
- New helper preserves dots, underscores, and case (all valid in k8s label values), unlike \`sanitize_k8s_name\` which is DNS-label-strict.

## Test plan
- [x] \`bundle exec rake\` — added unit coverage for the helper and the \`get_labels\` wiring.