### PR TITLE
Validate namespace and URL-encode WebSocket path segments

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -97,9 +97,7 @@ module Beaker
       @options = options
       @namespace = @options[:namespace]
       raise 'Namespace must be specified in options' unless @namespace
-      unless @namespace.is_a?(String) && NAMESPACE_RE.match?(@namespace)
-        raise ArgumentError, "Invalid namespace #{@namespace.inspect}: must match RFC 1123 DNS label"
-      end
+      raise ArgumentError, "Invalid namespace #{@namespace.inspect}: must match RFC 1123 DNS label" unless @namespace.is_a?(String) && NAMESPACE_RE.match?(@namespace)
 
       @service_account = @options[:kubevirt_service_account]
 

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -48,6 +48,9 @@ module Beaker
     # Kubernetes label-value maximum length under Kubernetes label value constraints (63 chars).
     LABEL_VALUE_MAX = K8S_NAME_MAX
 
+    # RFC 1123 DNS label — same constraint kube-apiserver applies to namespaces.
+    NAMESPACE_RE = /\A[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?\z/
+
     # VMI phases that indicate the VM will never reach Running.
     VMI_TERMINAL_PHASES = %w[Failed Succeeded].freeze
     # virt-launcher container waiting reasons we treat as fatal.
@@ -94,6 +97,7 @@ module Beaker
       @options = options
       @namespace = @options[:namespace]
       raise 'Namespace must be specified in options' unless @namespace
+      raise ArgumentError, "Invalid namespace #{@namespace.inspect}: must match RFC 1123 DNS label" unless NAMESPACE_RE.match?(@namespace)
 
       @service_account = @options[:kubevirt_service_account]
 

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -97,7 +97,9 @@ module Beaker
       @options = options
       @namespace = @options[:namespace]
       raise 'Namespace must be specified in options' unless @namespace
-      raise ArgumentError, "Invalid namespace #{@namespace.inspect}: must match RFC 1123 DNS label" unless NAMESPACE_RE.match?(@namespace)
+      unless @namespace.is_a?(String) && NAMESPACE_RE.match?(@namespace)
+        raise ArgumentError, "Invalid namespace #{@namespace.inspect}: must match RFC 1123 DNS label"
+      end
 
       @service_account = @options[:kubevirt_service_account]
 

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -6,6 +6,7 @@ require 'eventmachine'
 require 'socket'
 require 'logger'
 require 'json'
+require 'uri'
 
 # KubeVirtPortForwarder acts as a local TCP proxy for a port on a KubeVirt VMI.
 # It handles the entire lifecycle of discovering the VMI, establishing a
@@ -259,7 +260,9 @@ class KubeVirtPortForwarder
     path_prefix = uri.path.to_s.sub(%r{/api.*$}, '')
     base_url += path_prefix unless path_prefix.empty? || path_prefix == '/'
     base_ws_url = base_url.sub(/^http/, 'ws')
-    url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{@namespace}/virtualmachineinstances/#{@vmi_name}/portforward/#{@target_port}"
+    ns = URI.encode_www_form_component(@namespace)
+    vmi = URI.encode_www_form_component(@vmi_name)
+    url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{ns}/virtualmachineinstances/#{vmi}/portforward/#{@target_port.to_i}"
     @logger.debug("WebSocket URL: #{url}")
 
     auth_token = @kube_client.auth_options[:bearer_token]

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -263,9 +263,8 @@ class KubeVirtPortForwarder
     ns = URI.encode_www_form_component(@namespace)
     vmi = URI.encode_www_form_component(@vmi_name)
     target_port = Integer(@target_port, exception: false)
-    unless target_port && target_port.between?(1, 65_535)
-      raise ArgumentError, "Invalid target port: #{@target_port.inspect}. Expected an integer between 1 and 65535."
-    end
+    raise ArgumentError, "Invalid target port: #{@target_port.inspect}. Expected an integer between 1 and 65535." unless target_port&.between?(1, 65_535)
+
     url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{ns}/virtualmachineinstances/#{vmi}/portforward/#{target_port}"
     @logger.debug("WebSocket URL: #{url}")
 

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -262,7 +262,11 @@ class KubeVirtPortForwarder
     base_ws_url = base_url.sub(/^http/, 'ws')
     ns = URI.encode_www_form_component(@namespace)
     vmi = URI.encode_www_form_component(@vmi_name)
-    url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{ns}/virtualmachineinstances/#{vmi}/portforward/#{@target_port.to_i}"
+    target_port = Integer(@target_port, exception: false)
+    unless target_port && target_port.between?(1, 65_535)
+      raise ArgumentError, "Invalid target port: #{@target_port.inspect}. Expected an integer between 1 and 65535."
+    end
+    url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{ns}/virtualmachineinstances/#{vmi}/portforward/#{target_port}"
     @logger.debug("WebSocket URL: #{url}")
 
     auth_token = @kube_client.auth_options[:bearer_token]

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -666,6 +666,91 @@ RSpec.describe KubeVirtPortForwarder do
         # Check that we don't have triple slashes or double slashes in the path
         expect(captured_url).not_to match(%r{://.*//})
       end
+
+      it 'percent-encodes namespace and vmi_name path separators in the URL' do
+        kube_client = instance_double(
+          Kubeclient::Client,
+          api_endpoint: URI.parse('https://kubernetes.example.com/api'),
+          auth_options: { bearer_token: 'test-token' },
+          ssl_options: {},
+        )
+        forwarder = described_class.new(
+          kube_client: kube_client,
+          namespace: 'my/namespace',
+          vmi_name: 'my/vmi',
+          target_port: 22,
+          local_port: 10_022,
+          logger: logger,
+        )
+
+        client_socket = instance_double(TCPSocket, closed?: false)
+
+        captured_url = nil
+        allow(Faye::WebSocket::Client).to receive(:new) do |url, _protocols, _options|
+          captured_url = url
+          instance_double(Faye::WebSocket::Client, on: nil)
+        end
+
+        connection_status_q = Queue.new
+        allow(Queue).to receive(:new).and_return(connection_status_q)
+        allow(EventMachine).to receive(:schedule) do |&block|
+          block.call
+          connection_status_q.push(RuntimeError.new('Connection failed'))
+        end
+
+        forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
+
+        expect(captured_url).to include('/namespaces/my%2Fnamespace/')
+        expect(captured_url).to include('/virtualmachineinstances/my%2Fvmi/')
+        expect(captured_url).not_to include('/namespaces/my/namespace/')
+        expect(captured_url).not_to include('/virtualmachineinstances/my/vmi/')
+      end
+
+      it 'raises ArgumentError for a non-numeric target_port' do
+        kube_client = instance_double(
+          Kubeclient::Client,
+          api_endpoint: URI.parse('https://kubernetes.example.com/api'),
+          auth_options: { bearer_token: 'test-token' },
+          ssl_options: {},
+        )
+        forwarder = described_class.new(
+          kube_client: kube_client,
+          namespace: 'default',
+          vmi_name: 'test-vm',
+          target_port: 'abc',
+          local_port: 10_022,
+          logger: logger,
+        )
+
+        client_socket = instance_double(TCPSocket, closed?: false)
+
+        expect do
+          forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
+        end.to raise_error(ArgumentError, /Invalid target port/)
+      end
+
+      it 'raises ArgumentError for target_port out of valid range' do
+        kube_client = instance_double(
+          Kubeclient::Client,
+          api_endpoint: URI.parse('https://kubernetes.example.com/api'),
+          auth_options: { bearer_token: 'test-token' },
+          ssl_options: {},
+        )
+        forwarder = described_class.new(
+          kube_client: kube_client,
+          namespace: 'default',
+          vmi_name: 'test-vm',
+          target_port: 99_999,
+          local_port: 10_022,
+          logger: logger,
+        )
+
+        client_socket = instance_double(TCPSocket, closed?: false)
+
+        expect do
+          forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
+        end.to raise_error(ArgumentError, /Invalid target port/)
+      end
     end
 
     # Fix: Bearer token only set when present

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe Beaker::Kubevirt do
 
       expect(test_group_id).to match(/^beaker-[a-f0-9]{8}$/)
     end
+
+    it 'rejects namespaces that contain path separators' do
+      bad_options = options.merge(namespace: 'foo/../bar')
+      expect do
+        described_class.new(hosts, bad_options)
+      end.to raise_error(ArgumentError, /RFC 1123 DNS label/)
+    end
+
+    it 'rejects uppercase namespaces' do
+      bad_options = options.merge(namespace: 'FOO')
+      expect do
+        described_class.new(hosts, bad_options)
+      end.to raise_error(ArgumentError, /RFC 1123 DNS label/)
+    end
   end
 
   describe '#provision' do


### PR DESCRIPTION
## Summary
- Reject non-RFC-1123 namespaces up front, matching what kube-apiserver enforces. Prevents a hosts.yaml-controlled attacker from rewriting the port-forward WebSocket URL to an arbitrary apiserver endpoint while still attaching the operator's bearer token.
- URL-encode \`@namespace\` and \`@vmi_name\` at the interpolation site and coerce \`@target_port\` to Integer as defence in depth.

## Test plan
- [x] \`bundle exec rake\` — new specs cover uppercase / path-separator rejection.