### PR TITLE
Bound EventMachine reactor startup wait

### DIFF
--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -232,7 +232,9 @@ class KubeVirtPortForwarder
         end
         raise 'EventMachine reactor thread exited during startup with no exception'
       end
-      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if Time.now > deadline
+      if Time.now > deadline
+        raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" unless EventMachine.reactor_running?
+      end
 
       sleep 0.1
     end

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -268,7 +268,7 @@ class KubeVirtPortForwarder
   # Block until EventMachine.reactor_running? becomes true, or fail fast
   # if the reactor thread died during startup or the deadline elapses.
   def wait_for_reactor_ready
-    deadline = Time.now + REACTOR_STARTUP_TIMEOUT
+    deadline = monotonic_now + REACTOR_STARTUP_TIMEOUT
     until EventMachine.reactor_running?
       unless @reactor_thread.alive?
         begin
@@ -286,7 +286,7 @@ class KubeVirtPortForwarder
         end
         raise 'EventMachine reactor thread exited during startup with no exception'
       end
-      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (Time.now > deadline) && !EventMachine.reactor_running?
+      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (monotonic_now > deadline) && !EventMachine.reactor_running?
 
       sleep 0.1
     end
@@ -297,13 +297,20 @@ class KubeVirtPortForwarder
   # its rescue/stop path; if that happens before the reactor came up, we bail
   # out rather than wait the full deadline.
   def wait_for_existing_reactor_ready
-    deadline = Time.now + REACTOR_STARTUP_TIMEOUT
+    deadline = monotonic_now + REACTOR_STARTUP_TIMEOUT
     until EventMachine.reactor_running?
       raise 'EventMachine reactor owner cleared before reactor became ready' if self.class.reactor_owner.nil?
-      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (Time.now > deadline) && !EventMachine.reactor_running?
+      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (monotonic_now > deadline) && !EventMachine.reactor_running?
 
       sleep 0.1
     end
+  end
+
+  # Monotonic clock for deadline arithmetic. Time.now is wall-clock and can
+  # jump forwards/backwards on NTP adjustments, producing spurious timeouts
+  # or longer-than-expected waits.
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
   # Handles a single client connection from start to finish.

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -300,7 +300,7 @@ class KubeVirtPortForwarder
     deadline = Time.now + REACTOR_STARTUP_TIMEOUT
     until EventMachine.reactor_running?
       raise 'EventMachine reactor owner cleared before reactor became ready' if self.class.reactor_owner.nil?
-      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if Time.now > deadline
+      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (Time.now > deadline) && !EventMachine.reactor_running?
 
       sleep 0.1
     end

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -203,7 +203,15 @@ class KubeVirtPortForwarder
 
     if should_stop_reactor
       EventMachine.stop if EventMachine.reactor_running?
-      @reactor_thread&.join
+      begin
+        @reactor_thread&.join
+      # Thread#join re-raises whatever the thread terminated with, which can
+      # be a non-StandardError (e.g. LoadError from a native-extension issue
+      # we already surfaced via wait_for_reactor_ready). Swallow it during
+      # teardown so it doesn't abort the rest of cleanup.
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        @logger.debug("Reactor thread terminated with exception during shutdown: #{e.class}: #{e.message}")
+      end
       @logger.debug('Stopped EventMachine reactor (owned by this forwarder)')
     else
       @logger.debug('Not stopping EventMachine reactor (owned by another forwarder)')

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -36,6 +36,12 @@ class KubeVirtPortForwarder
   # The channel byte for the error stream from the server.
   ERROR_CHANNEL = "\x01"
 
+  # Upper bound on how long we'll wait for EventMachine.reactor_running? to
+  # become true after kicking off EventMachine.run in its own thread. Healthy
+  # startup is well under 100ms; five seconds is only reached when something
+  # is wrong (native-ext load failure, incompatible libcrypto, etc.).
+  REACTOR_STARTUP_TIMEOUT = 5
+
   # Class-level tracking of EventMachine reactor ownership
   # EventMachine has a single global reactor, so we need to track which
   # forwarder instance started it to avoid stopping it prematurely
@@ -93,8 +99,7 @@ class KubeVirtPortForwarder
 
     if start_reactor
       @reactor_thread = Thread.new { EventMachine.run }
-      # Wait for the reactor to be running
-      sleep 0.1 until EventMachine.reactor_running?
+      wait_for_reactor_ready
       @logger.debug('Started EventMachine reactor (owned by this forwarder)')
     else
       @logger.debug('Using existing EventMachine reactor (owned by another forwarder)')
@@ -209,6 +214,25 @@ class KubeVirtPortForwarder
   end
 
   private
+
+  # Block until EventMachine.reactor_running? becomes true, or fail fast
+  # if the reactor thread died during startup or the deadline elapses.
+  def wait_for_reactor_ready
+    deadline = Time.now + REACTOR_STARTUP_TIMEOUT
+    until EventMachine.reactor_running?
+      unless @reactor_thread.alive?
+        begin
+          @reactor_thread.value # re-raises the thread's exception, if any
+        rescue StandardError => e
+          raise "EventMachine reactor thread exited during startup: #{e.class}: #{e.message}"
+        end
+        raise 'EventMachine reactor thread exited during startup with no exception'
+      end
+      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if Time.now > deadline
+
+      sleep 0.1
+    end
+  end
 
   # Handles a single client connection from start to finish.
   # @param client_socket [TCPSocket] The socket connected to the client.

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -223,8 +223,12 @@ class KubeVirtPortForwarder
       unless @reactor_thread.alive?
         begin
           @reactor_thread.value # re-raises the thread's exception, if any
-        rescue StandardError => e
-          raise "EventMachine reactor thread exited during startup: #{e.class}: #{e.message}"
+        rescue Exception => e
+          startup_error = RuntimeError.new(
+            "EventMachine reactor thread exited during startup: #{e.class}: #{e.message}"
+          )
+          startup_error.set_backtrace(e.backtrace)
+          raise startup_error, cause: e
         end
         raise 'EventMachine reactor thread exited during startup with no exception'
       end

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -227,11 +227,11 @@ class KubeVirtPortForwarder
   # Thread#value in wait_for_reactor_ready, so swallowing the same class
   # here during teardown is safe; signals (Interrupt/SystemExit) propagate.
   def shut_down_reactor_thread
-    return unless @reactor_thread
+    reactor_thread = @reactor_thread
+    return unless reactor_thread
 
-    deadline_thread = @reactor_thread
     begin
-      joined = deadline_thread.join(REACTOR_SHUTDOWN_TIMEOUT)
+      joined = reactor_thread.join(REACTOR_SHUTDOWN_TIMEOUT)
     rescue StandardError, ScriptError => e
       @logger.debug("Reactor thread terminated with exception during shutdown: #{e.class}: #{e.message}")
       return
@@ -240,12 +240,17 @@ class KubeVirtPortForwarder
     return if joined
 
     @logger.warn("Force-killing reactor thread that didn't shut down within #{REACTOR_SHUTDOWN_TIMEOUT}s")
-    deadline_thread.kill
+    reactor_thread.kill
+    # Thread#kill won't interrupt an uninterruptible native call, so bound this
+    # join too — we'd rather leak a hung thread than block shutdown forever.
     begin
-      deadline_thread.join
+      joined = reactor_thread.join(REACTOR_SHUTDOWN_TIMEOUT)
     rescue StandardError, ScriptError
-      nil
+      joined = true
     end
+    return if joined
+
+    @logger.error("Reactor thread still alive #{REACTOR_SHUTDOWN_TIMEOUT}s after kill; abandoning it (likely stuck in a native call)")
   end
 
   # Block until EventMachine.reactor_running? becomes true, or fail fast

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -94,10 +94,16 @@ class KubeVirtPortForwarder
     @shutdown = false
 
     # Start the EventMachine reactor in a dedicated thread to handle WebSocket I/O.
-    # EventMachine has a single global reactor, so we need to check if it's already running
+    # EventMachine has a single global reactor, so we need to check if it's already
+    # running. Guarding only on EventMachine.reactor_running? would race: a second
+    # forwarder entering this block before the first reactor thread has actually
+    # become "running" would also see false, set itself as owner, and spawn a
+    # second EventMachine.run thread. Guard on reactor_owner.nil? as well so the
+    # owner is locked in atomically — a non-owner just waits for the in-progress
+    # reactor to become ready.
     start_reactor = false
     self.class.reactor_owner_mutex.synchronize do
-      unless EventMachine.reactor_running?
+      if self.class.reactor_owner.nil? && !EventMachine.reactor_running?
         start_reactor = true
         self.class.reactor_owner = self
       end
@@ -108,6 +114,7 @@ class KubeVirtPortForwarder
       wait_for_reactor_ready
       @logger.debug('Started EventMachine reactor (owned by this forwarder)')
     else
+      wait_for_existing_reactor_ready
       @logger.debug('Using existing EventMachine reactor (owned by another forwarder)')
     end
 
@@ -275,6 +282,20 @@ class KubeVirtPortForwarder
         raise 'EventMachine reactor thread exited during startup with no exception'
       end
       raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (Time.now > deadline) && !EventMachine.reactor_running?
+
+      sleep 0.1
+    end
+  end
+
+  # Wait (bounded) for a reactor that another forwarder is starting to become
+  # ready. If the owning forwarder's startup fails, it clears reactor_owner in
+  # its rescue/stop path; if that happens before the reactor came up, we bail
+  # out rather than wait the full deadline.
+  def wait_for_existing_reactor_ready
+    deadline = Time.now + REACTOR_STARTUP_TIMEOUT
+    until EventMachine.reactor_running?
+      raise 'EventMachine reactor owner cleared before reactor became ready' if self.class.reactor_owner.nil?
+      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if Time.now > deadline
 
       sleep 0.1
     end

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -223,18 +223,20 @@ class KubeVirtPortForwarder
       unless @reactor_thread.alive?
         begin
           @reactor_thread.value # re-raises the thread's exception, if any
-        rescue Exception => e
+        # The reactor thread typically dies from non-StandardError causes such as
+        # LoadError (native extension failure) or other ScriptError subclasses.
+        # Rescue Exception so we can wrap and re-raise *any* cause with context;
+        # we do not swallow it (raise below preserves :cause and backtrace).
+        rescue Exception => e # rubocop:disable Lint/RescueException
           startup_error = RuntimeError.new(
-            "EventMachine reactor thread exited during startup: #{e.class}: #{e.message}"
+            "EventMachine reactor thread exited during startup: #{e.class}: #{e.message}",
           )
           startup_error.set_backtrace(e.backtrace)
           raise startup_error, cause: e
         end
         raise 'EventMachine reactor thread exited during startup with no exception'
       end
-      if Time.now > deadline
-        raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" unless EventMachine.reactor_running?
-      end
+      raise "EventMachine reactor did not become ready within #{REACTOR_STARTUP_TIMEOUT}s" if (Time.now > deadline) && !EventMachine.reactor_running?
 
       sleep 0.1
     end

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -42,6 +42,12 @@ class KubeVirtPortForwarder
   # is wrong (native-ext load failure, incompatible libcrypto, etc.).
   REACTOR_STARTUP_TIMEOUT = 5
 
+  # Upper bound on how long we'll wait for the reactor thread to exit during
+  # shutdown after EventMachine.stop. If startup timed out, the reactor thread
+  # is alive but hung and EventMachine.stop is a no-op, so we must kill it
+  # rather than block forever on join.
+  REACTOR_SHUTDOWN_TIMEOUT = 5
+
   # Class-level tracking of EventMachine reactor ownership
   # EventMachine has a single global reactor, so we need to track which
   # forwarder instance started it to avoid stopping it prematurely
@@ -203,15 +209,7 @@ class KubeVirtPortForwarder
 
     if should_stop_reactor
       EventMachine.stop if EventMachine.reactor_running?
-      begin
-        @reactor_thread&.join
-      # Thread#join re-raises whatever the thread terminated with, which can
-      # be a non-StandardError (e.g. LoadError from a native-extension issue
-      # we already surfaced via wait_for_reactor_ready). Swallow it during
-      # teardown so it doesn't abort the rest of cleanup.
-      rescue Exception => e # rubocop:disable Lint/RescueException
-        @logger.debug("Reactor thread terminated with exception during shutdown: #{e.class}: #{e.message}")
-      end
+      shut_down_reactor_thread
       @logger.debug('Stopped EventMachine reactor (owned by this forwarder)')
     else
       @logger.debug('Not stopping EventMachine reactor (owned by another forwarder)')
@@ -222,6 +220,33 @@ class KubeVirtPortForwarder
   end
 
   private
+
+  # Wait for the reactor thread to exit, with a bounded timeout and a
+  # last-resort kill. Mirrors the connection-thread shutdown logic above.
+  # The reactor thread's exception (if any) was already surfaced via
+  # Thread#value in wait_for_reactor_ready, so swallowing the same class
+  # here during teardown is safe; signals (Interrupt/SystemExit) propagate.
+  def shut_down_reactor_thread
+    return unless @reactor_thread
+
+    deadline_thread = @reactor_thread
+    begin
+      joined = deadline_thread.join(REACTOR_SHUTDOWN_TIMEOUT)
+    rescue StandardError, ScriptError => e
+      @logger.debug("Reactor thread terminated with exception during shutdown: #{e.class}: #{e.message}")
+      return
+    end
+
+    return if joined
+
+    @logger.warn("Force-killing reactor thread that didn't shut down within #{REACTOR_SHUTDOWN_TIMEOUT}s")
+    deadline_thread.kill
+    begin
+      deadline_thread.join
+    rescue StandardError, ScriptError
+      nil
+    end
+  end
 
   # Block until EventMachine.reactor_running? becomes true, or fail fast
   # if the reactor thread died during startup or the deadline elapses.

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -200,8 +200,10 @@ RSpec.describe KubeVirtPortForwarder do
 
       it 'fails fast with a deadline error if the reactor never becomes ready' do
         stub_const("#{described_class}::REACTOR_STARTUP_TIMEOUT", 0.1)
-        # Reactor thread stays alive but never flips reactor_running? to true
-        allow(EventMachine).to receive(:run) { sleep 5 }
+        # Reactor thread stays alive but never flips reactor_running? to true.
+        # Sleep just long enough to outlast the stubbed startup deadline; the
+        # bounded join + kill in stop ensures shutdown doesn't block on it.
+        allow(EventMachine).to receive(:run) { sleep 0.5 }
 
         captured = nil
         forwarder.instance_variable_set(:@on_error, ->(e) { captured = e })
@@ -211,6 +213,23 @@ RSpec.describe KubeVirtPortForwarder do
         expect(forwarder.state).to eq(:stopped)
         expect(captured).to be_a(RuntimeError)
         expect(captured.message).to match(/reactor did not become ready within/)
+      end
+
+      it 'force-kills the reactor thread if it does not exit within the shutdown timeout' do
+        stub_const("#{described_class}::REACTOR_STARTUP_TIMEOUT", 0.1)
+        stub_const("#{described_class}::REACTOR_SHUTDOWN_TIMEOUT", 0.1)
+        # Reactor thread stays alive much longer than the shutdown timeout.
+        allow(EventMachine).to receive(:run) { sleep 10 }
+
+        forwarder.instance_variable_set(:@on_error, ->(_) {})
+
+        expect(logger).to receive(:warn).with(/Force-killing reactor thread/)
+
+        forwarder.start
+
+        reactor_thread = forwarder.instance_variable_get(:@reactor_thread)
+        expect(forwarder.state).to eq(:stopped)
+        expect(reactor_thread).not_to be_alive
       end
     end
   end

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -251,7 +251,15 @@ RSpec.describe KubeVirtPortForwarder do
         )
       end
 
-      after { forwarder2.stop if forwarder2.state != :stopped }
+      let(:helper_threads) { [] }
+
+      after do
+        # Make sure background helpers from each example are joined before the
+        # next one runs — they mutate shared class state (@reactor_running,
+        # reactor_owner) and would cause flakes if they leaked across examples.
+        helper_threads.each(&:join)
+        forwarder2.stop if forwarder2.state != :stopped
+      end
 
       it 'does not spawn a second EventMachine.run thread or overwrite reactor_owner' do
         # Simulate forwarder1's reactor still mid-startup: owner is set but
@@ -261,7 +269,7 @@ RSpec.describe KubeVirtPortForwarder do
 
         # Flip the reactor "ready" shortly after forwarder2 starts so its
         # bounded wait completes.
-        Thread.new do
+        helper_threads << Thread.new do
           sleep 0.05
           @reactor_running = true
         end
@@ -277,7 +285,7 @@ RSpec.describe KubeVirtPortForwarder do
         described_class.reactor_owner = forwarder
         @reactor_running = false
 
-        Thread.new do
+        helper_threads << Thread.new do
           sleep 0.05
           described_class.reactor_owner = nil
         end
@@ -289,6 +297,21 @@ RSpec.describe KubeVirtPortForwarder do
 
         expect(forwarder2.state).to eq(:stopped)
         expect(captured.message).to include('reactor owner cleared before reactor became ready')
+      end
+
+      it 'fails fast with a deadline error if the in-progress reactor never becomes ready' do
+        stub_const("#{described_class}::REACTOR_STARTUP_TIMEOUT", 0.1)
+        described_class.reactor_owner = forwarder
+        @reactor_running = false
+
+        captured = nil
+        forwarder2.instance_variable_set(:@on_error, ->(e) { captured = e })
+
+        forwarder2.start
+
+        expect(forwarder2.state).to eq(:stopped)
+        expect(captured).to be_a(RuntimeError)
+        expect(captured.message).to match(/reactor did not become ready within/)
       end
     end
   end

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -232,6 +232,65 @@ RSpec.describe KubeVirtPortForwarder do
         expect(reactor_thread).not_to be_alive
       end
     end
+
+    # Two forwarders entering the reactor-startup section concurrently must not
+    # both spawn EventMachine.run threads. Even though the first is mid-startup,
+    # EventMachine.reactor_running? is still false until its thread runs — so a
+    # check on reactor_running? alone would let a second forwarder also claim
+    # ownership. Guard on reactor_owner.nil? to make ownership atomic.
+    context 'when another forwarder is mid-startup' do
+      let(:forwarder2) do
+        described_class.new(
+          kube_client: kube_client,
+          namespace: namespace,
+          vmi_name: vmi_name,
+          target_port: target_port,
+          local_port: local_port + 1,
+          logger: logger,
+          on_error: on_error,
+        )
+      end
+
+      after { forwarder2.stop if forwarder2.state != :stopped }
+
+      it 'does not spawn a second EventMachine.run thread or overwrite reactor_owner' do
+        # Simulate forwarder1's reactor still mid-startup: owner is set but
+        # reactor_running? has not flipped to true yet.
+        described_class.reactor_owner = forwarder
+        @reactor_running = false
+
+        # Flip the reactor "ready" shortly after forwarder2 starts so its
+        # bounded wait completes.
+        Thread.new do
+          sleep 0.05
+          @reactor_running = true
+        end
+
+        forwarder2.start
+
+        expect(EventMachine).not_to have_received(:run)
+        expect(described_class.reactor_owner).to eq(forwarder)
+        expect(forwarder2.state).to eq(:running)
+      end
+
+      it 'fails fast if the in-progress owner clears itself before the reactor comes up' do
+        described_class.reactor_owner = forwarder
+        @reactor_running = false
+
+        Thread.new do
+          sleep 0.05
+          described_class.reactor_owner = nil
+        end
+
+        captured = nil
+        forwarder2.instance_variable_set(:@on_error, ->(e) { captured = e })
+
+        forwarder2.start
+
+        expect(forwarder2.state).to eq(:stopped)
+        expect(captured.message).to include('reactor owner cleared before reactor became ready')
+      end
+    end
   end
 
   describe '#stop' do

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -162,6 +162,57 @@ RSpec.describe KubeVirtPortForwarder do
 
       expect(forwarder.state).to eq(initial_state)
     end
+
+    # Issue: EventMachine reactor startup could spin forever if the reactor
+    # thread died (e.g. native lib mismatch) or never became ready.
+    context 'when the EventMachine reactor fails to start' do
+      it 'fails fast and reports the original cause if the reactor thread raises a StandardError' do
+        boom = RuntimeError.new('boom from reactor thread')
+        allow(EventMachine).to receive(:run).and_raise(boom)
+
+        captured = nil
+        forwarder.instance_variable_set(:@on_error, ->(e) { captured = e })
+
+        forwarder.start
+
+        expect(forwarder.state).to eq(:stopped)
+        expect(captured).to be_a(RuntimeError)
+        expect(captured.message).to include('EventMachine reactor thread exited during startup')
+        expect(captured.message).to include('boom from reactor thread')
+        expect(captured.cause).to eq(boom)
+      end
+
+      it 'fails fast and reports the original cause if the reactor thread raises a non-StandardError' do
+        boom = LoadError.new('libcrypto symbol mismatch')
+        allow(EventMachine).to receive(:run).and_raise(boom)
+
+        captured = nil
+        forwarder.instance_variable_set(:@on_error, ->(e) { captured = e })
+
+        forwarder.start
+
+        expect(forwarder.state).to eq(:stopped)
+        expect(captured).to be_a(RuntimeError)
+        expect(captured.message).to include('LoadError')
+        expect(captured.message).to include('libcrypto symbol mismatch')
+        expect(captured.cause).to eq(boom)
+      end
+
+      it 'fails fast with a deadline error if the reactor never becomes ready' do
+        stub_const("#{described_class}::REACTOR_STARTUP_TIMEOUT", 0.1)
+        # Reactor thread stays alive but never flips reactor_running? to true
+        allow(EventMachine).to receive(:run) { sleep 5 }
+
+        captured = nil
+        forwarder.instance_variable_set(:@on_error, ->(e) { captured = e })
+
+        forwarder.start
+
+        expect(forwarder.state).to eq(:stopped)
+        expect(captured).to be_a(RuntimeError)
+        expect(captured.message).to match(/reactor did not become ready within/)
+      end
+    end
   end
 
   describe '#stop' do


### PR DESCRIPTION
## Summary
- Replace the open-ended \`sleep 0.1 until EventMachine.reactor_running?\` with a 5s deadline plus a thread-liveness check.
- If the reactor thread died during startup (libcrypto mismatch, partial gem upgrade, etc.), re-raise its exception instead of spinning at 10 Hz forever.

## Test plan
- [x] \`bundle exec rake\` — happy path unchanged.