### PR TITLE
Unlink kubeconfig-derived tempfiles at cleanup

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -182,26 +182,9 @@ module Beaker
 
       @logger.info("Cleaning up resources in namespace: #{@namespace}")
       begin
-        begin
-          # Cleanup VMs associated with the test group
-          @kubevirt_helper.cleanup_vms(@test_group_identifier)
-        rescue StandardError => e
-          @logger.error("Error cleaning up VMs: #{e.message}")
-        end
-
-        begin
-          # Cleanup secrets associated with the test group
-          @kubevirt_helper.cleanup_secrets(@test_group_identifier)
-        rescue StandardError => e
-          @logger.error("Error cleaning up secrets: #{e.message}")
-        end
-
-        begin
-          # Cleanup services associated with the test group
-          @kubevirt_helper.cleanup_services(@test_group_identifier)
-        rescue StandardError => e
-          @logger.error("Error cleaning up services: #{e.message}")
-        end
+        safe_cleanup('cleaning up VMs') { @kubevirt_helper.cleanup_vms(@test_group_identifier) }
+        safe_cleanup('cleaning up secrets') { @kubevirt_helper.cleanup_secrets(@test_group_identifier) }
+        safe_cleanup('cleaning up services') { @kubevirt_helper.cleanup_services(@test_group_identifier) }
       ensure
         # Finally unlink the kubeconfig-derived tempfiles — must be last
         # because the preceding cleanups still need them for auth.
@@ -252,6 +235,15 @@ module Beaker
         @logger.error("Error during at_exit cleanup: #{e.message}")
         @logger.debug(e.backtrace.join("\n"))
       end
+    end
+
+    ##
+    # Execute a cleanup operation, logging any errors without re-raising them.
+    # @param [String] description A short description for the error message
+    def safe_cleanup(description)
+      yield
+    rescue StandardError => e
+      @logger.error("Error #{description}: #{e.message}")
     end
 
     ##

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -187,6 +187,9 @@ module Beaker
       @kubevirt_helper.cleanup_secrets(@test_group_identifier)
       # Cleanup services associated with the test group
       @kubevirt_helper.cleanup_services(@test_group_identifier)
+      # Finally unlink the kubeconfig-derived tempfiles — must be last
+      # because the preceding cleanups still need them for auth.
+      @kubevirt_helper.cleanup_temp_files if @kubevirt_helper.respond_to?(:cleanup_temp_files)
     end
 
     ##

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -181,15 +181,32 @@ module Beaker
       end
 
       @logger.info("Cleaning up resources in namespace: #{@namespace}")
-      # Cleanup VMs associated with the test group
-      @kubevirt_helper.cleanup_vms(@test_group_identifier)
-      # Cleanup secrets associated with the test group
-      @kubevirt_helper.cleanup_secrets(@test_group_identifier)
-      # Cleanup services associated with the test group
-      @kubevirt_helper.cleanup_services(@test_group_identifier)
-      # Finally unlink the kubeconfig-derived tempfiles — must be last
-      # because the preceding cleanups still need them for auth.
-      @kubevirt_helper.cleanup_temp_files
+      begin
+        begin
+          # Cleanup VMs associated with the test group
+          @kubevirt_helper.cleanup_vms(@test_group_identifier)
+        rescue StandardError => e
+          @logger.error("Error cleaning up VMs: #{e.message}")
+        end
+
+        begin
+          # Cleanup secrets associated with the test group
+          @kubevirt_helper.cleanup_secrets(@test_group_identifier)
+        rescue StandardError => e
+          @logger.error("Error cleaning up secrets: #{e.message}")
+        end
+
+        begin
+          # Cleanup services associated with the test group
+          @kubevirt_helper.cleanup_services(@test_group_identifier)
+        rescue StandardError => e
+          @logger.error("Error cleaning up services: #{e.message}")
+        end
+      ensure
+        # Finally unlink the kubeconfig-derived tempfiles — must be last
+        # because the preceding cleanups still need them for auth.
+        @kubevirt_helper.cleanup_temp_files
+      end
     end
 
     ##

--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -189,7 +189,7 @@ module Beaker
       @kubevirt_helper.cleanup_services(@test_group_identifier)
       # Finally unlink the kubeconfig-derived tempfiles — must be last
       # because the preceding cleanups still need them for auth.
-      @kubevirt_helper.cleanup_temp_files if @kubevirt_helper.respond_to?(:cleanup_temp_files)
+      @kubevirt_helper.cleanup_temp_files
     end
 
     ##

--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -271,6 +271,23 @@ module Beaker
     end
 
     ##
+    # Unlink the kubeconfig-derived cert/key tempfiles kept alive for the
+    # process lifetime. Safe to call after all API operations that need the
+    # files have completed.
+    def cleanup_temp_files
+      return unless @temp_files
+
+      @temp_files.each do |file|
+        path = file.path
+        file.close unless file.closed?
+        file.unlink
+      rescue StandardError => e
+        @logger&.warn("Failed to unlink temp file #{path}: #{e.message}")
+      end
+      @temp_files.clear
+    end
+
+    ##
     # Get a cluster node IP address
     # @return [String] Node IP address
     def node_ip

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_vms)
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
+        allow(kubevirt_helper).to receive(:cleanup_temp_files)
         hypervisor.cleanup
       end
 
@@ -113,6 +114,32 @@ RSpec.describe Beaker::Kubevirt do
 
       it 'cleans up services' do
         expect(kubevirt_helper).to have_received(:cleanup_services).with(anything)
+      end
+
+      it 'cleans up temp files' do
+        expect(kubevirt_helper).to have_received(:cleanup_temp_files)
+      end
+    end
+
+    context 'when an earlier cleanup step raises an error' do
+      let(:hypervisor) { described_class.new(hosts, options) }
+
+      before do
+        allow(kubevirt_helper).to receive(:cleanup_vms).and_raise(StandardError, 'VM cleanup failed')
+        allow(kubevirt_helper).to receive(:cleanup_secrets)
+        allow(kubevirt_helper).to receive(:cleanup_services)
+        allow(kubevirt_helper).to receive(:cleanup_temp_files)
+      end
+
+      it 'still cleans up temp files when cleanup_vms raises' do
+        hypervisor.cleanup
+        expect(kubevirt_helper).to have_received(:cleanup_temp_files)
+      end
+
+      it 'still cleans up remaining resources when cleanup_vms raises' do
+        hypervisor.cleanup
+        expect(kubevirt_helper).to have_received(:cleanup_secrets)
+        expect(kubevirt_helper).to have_received(:cleanup_services)
       end
     end
 
@@ -139,6 +166,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_vms)
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
+        allow(kubevirt_helper).to receive(:cleanup_temp_files)
         hypervisor_with_port_forward.cleanup(delay: 0.25)
       end
 
@@ -172,6 +200,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_vms)
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
+        allow(kubevirt_helper).to receive(:cleanup_temp_files)
         hypervisor_with_port_forward.cleanup
       end
 
@@ -205,6 +234,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_vms)
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
+        allow(kubevirt_helper).to receive(:cleanup_temp_files)
       end
 
       it 'raises a timeout error' do
@@ -1769,6 +1799,7 @@ RSpec.describe Beaker::Kubevirt do
       allow(kubevirt_helper).to receive(:cleanup_vms)
       allow(kubevirt_helper).to receive(:cleanup_secrets)
       allow(kubevirt_helper).to receive(:cleanup_services)
+      allow(kubevirt_helper).to receive(:cleanup_temp_files)
     end
 
     describe '#initialize' do
@@ -1803,6 +1834,7 @@ RSpec.describe Beaker::Kubevirt do
         expect(kubevirt_helper).to have_received(:cleanup_vms).once
         expect(kubevirt_helper).to have_received(:cleanup_secrets).once
         expect(kubevirt_helper).to have_received(:cleanup_services).once
+        expect(kubevirt_helper).to have_received(:cleanup_temp_files).once
       end
 
       it 'calls cleanup_impl to perform actual cleanup' do
@@ -1898,6 +1930,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_vms)
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
+        allow(kubevirt_helper).to receive(:cleanup_temp_files)
       end
 
       it 'cleanup_on_exit does not perform cleanup' do
@@ -1922,6 +1955,7 @@ RSpec.describe Beaker::Kubevirt do
         expect(kubevirt_helper).to have_received(:cleanup_vms)
         expect(kubevirt_helper).to have_received(:cleanup_secrets)
         expect(kubevirt_helper).to have_received(:cleanup_services)
+        expect(kubevirt_helper).to have_received(:cleanup_temp_files)
       end
 
       it 'cleanup_on_exit logs at_exit cleanup message' do
@@ -1969,6 +2003,7 @@ RSpec.describe Beaker::Kubevirt do
         expect(kubevirt_helper).to have_received(:cleanup_vms).once
         expect(kubevirt_helper).to have_received(:cleanup_secrets).once
         expect(kubevirt_helper).to have_received(:cleanup_services).once
+        expect(kubevirt_helper).to have_received(:cleanup_temp_files).once
       end
     end
 


### PR DESCRIPTION
## Summary
- Add \`cleanup_temp_files\` to KubevirtHelper and call it last from \`cleanup_impl\`, after VM / secret / service cleanup (which still need the certs for auth).
- Prevents /tmp accumulation on long-running Beaker processes and shortens the exposure window on shared CI runners.

## Test plan
- [x] \`bundle exec rake\`