### PR TITLE
Clean up DataVolumes labeled for the test group

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -195,6 +195,9 @@ module Beaker
       @logger.info("Cleaning up resources in namespace: #{@namespace}")
       begin
         safe_cleanup('cleaning up VMs') { @kubevirt_helper.cleanup_vms(@test_group_identifier) }
+        # DataVolumes (and their backing PVCs) — VMs first so the VMI
+        # releases the PVC before the DV delete tries to reclaim storage.
+        safe_cleanup('cleaning up DataVolumes') { @kubevirt_helper.cleanup_data_volumes(@test_group_identifier) }
         safe_cleanup('cleaning up secrets') { @kubevirt_helper.cleanup_secrets(@test_group_identifier) }
         safe_cleanup('cleaning up services') { @kubevirt_helper.cleanup_services(@test_group_identifier) }
       ensure

--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -8,7 +8,7 @@ require 'base64'
 module Beaker
   # Helper class for KubeVirt operations
   class KubevirtHelper
-    attr_reader :namespace, :options, :k8s_client, :kubevirt_client
+    attr_reader :namespace, :options, :k8s_client, :kubevirt_client, :cdi_client
 
     def initialize(options)
       @options = options
@@ -27,6 +27,7 @@ module Beaker
       # Allow injection of clients for testing
       @k8s_client = options[:k8s_client]
       @kubevirt_client = options[:kubevirt_client]
+      @cdi_client = options[:cdi_client]
 
       # Only setup clients if not provided (for testing)
       return if @k8s_client && @kubevirt_client
@@ -36,6 +37,7 @@ module Beaker
       @original_ssl_options = extract_ssl_from_kubeconfig
       setup_kubernetes_client
       setup_kubevirt_client
+      setup_cdi_client
     end
 
     ##
@@ -202,6 +204,39 @@ module Beaker
     end
 
     ##
+    # Cleanup DataVolumes associated with a test group. No-op if CDI isn't
+    # available on the cluster (the @cdi_client stays nil in that case).
+    # @param [String] test_group_identifier The identifier for the test group
+    def cleanup_data_volumes(test_group_identifier)
+      return unless @cdi_client
+
+      @logger.info("Cleaning up DataVolumes for test group: #{test_group_identifier}")
+      label_selector = "beaker/test-group=#{test_group_identifier}"
+
+      begin
+        dvs = @cdi_client.get_data_volumes(namespace: @namespace, label_selector: label_selector)
+      rescue StandardError => e
+        @logger.warn("Failed to list DataVolumes for cleanup: #{e.class}: #{e.message}")
+        return
+      end
+
+      @logger.info("Found #{dvs.length} DataVolume(s) with label #{label_selector}")
+
+      dvs.each do |dv|
+        md = dv[:metadata] || dv['metadata']
+        dv_name = md[:name] || md['name'] if md
+        next unless dv_name && !dv_name.empty?
+
+        @cdi_client.delete_data_volume(dv_name, @namespace)
+        @logger.info("Deleted DataVolume #{dv_name}")
+      rescue Kubeclient::ResourceNotFoundError
+        @logger.debug("DataVolume #{dv_name} not found during cleanup")
+      rescue StandardError => e
+        @logger.error("Error deleting DataVolume #{dv_name}: #{e.message}")
+      end
+    end
+
+    ##
     # Setup port forwarding for a VM
     # @param [String] vm_name The VM name
     # @param [Integer] vm_port The VM port to forward
@@ -345,6 +380,25 @@ module Beaker
       # For testing or when Kubeclient can't parse, fall back to manual parsing
       @logger&.warn("Failed to use Kubeclient::Config, falling back to manual parsing: #{e.message}")
       setup_kubevirt_client_manual
+    end
+
+    ##
+    # Setup CDI (Containerized Data Importer) API client used for managing
+    # DataVolumes. Best-effort: clusters without CDI installed will still be
+    # able to provision container-disk / direct-PVC VMs. If setup fails we
+    # log and leave @cdi_client nil; cleanup_data_volumes will no-op.
+    def setup_cdi_client
+      config = Kubeclient::Config.new(load_kubeconfig, File.dirname(@kubeconfig_path))
+      context_config = config.context(@kubecontext)
+      @cdi_client = Kubeclient::Client.new(
+        "#{context_config.api_endpoint}/apis/cdi.kubevirt.io",
+        'v1beta1',
+        ssl_options: context_config.ssl_options,
+        auth_options: context_config.auth_options,
+      )
+    rescue StandardError => e
+      @logger&.debug("CDI client setup skipped: #{e.class}: #{e.message}")
+      @cdi_client = nil
     end
 
     ##

--- a/lib/beaker/hypervisor/kubevirt_helper.rb
+++ b/lib/beaker/hypervisor/kubevirt_helper.rb
@@ -37,7 +37,7 @@ module Beaker
       @original_ssl_options = extract_ssl_from_kubeconfig
       setup_kubernetes_client
       setup_kubevirt_client
-      setup_cdi_client
+      setup_cdi_client unless @cdi_client
     end
 
     ##
@@ -225,7 +225,10 @@ module Beaker
       dvs.each do |dv|
         md = dv[:metadata] || dv['metadata']
         dv_name = md[:name] || md['name'] if md
-        next unless dv_name && !dv_name.empty?
+        unless dv_name && !dv_name.empty?
+          @logger.error("Skipping DataVolume with missing name: #{dv.inspect[0, 200]}")
+          next
+        end
 
         @cdi_client.delete_data_volume(dv_name, @namespace)
         @logger.info("Deleted DataVolume #{dv_name}")
@@ -385,17 +388,21 @@ module Beaker
     ##
     # Setup CDI (Containerized Data Importer) API client used for managing
     # DataVolumes. Best-effort: clusters without CDI installed will still be
-    # able to provision container-disk / direct-PVC VMs. If setup fails we
-    # log and leave @cdi_client nil; cleanup_data_volumes will no-op.
+    # able to provision container-disk / direct-PVC VMs. We probe the API
+    # group with a `discover` call so that clusters lacking CDI leave
+    # @cdi_client nil rather than appearing live and warning on every
+    # cleanup.
     def setup_cdi_client
       config = Kubeclient::Config.new(load_kubeconfig, File.dirname(@kubeconfig_path))
       context_config = config.context(@kubecontext)
-      @cdi_client = Kubeclient::Client.new(
+      client = Kubeclient::Client.new(
         "#{context_config.api_endpoint}/apis/cdi.kubevirt.io",
         'v1beta1',
         ssl_options: context_config.ssl_options,
         auth_options: context_config.auth_options,
       )
+      client.discover
+      @cdi_client = client
     rescue StandardError => e
       @logger&.debug("CDI client setup skipped: #{e.class}: #{e.message}")
       @cdi_client = nil

--- a/spec/beaker/kubevirt_spec.rb
+++ b/spec/beaker/kubevirt_spec.rb
@@ -101,11 +101,22 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
         allow(kubevirt_helper).to receive(:cleanup_temp_files)
+        allow(kubevirt_helper).to receive(:cleanup_data_volumes)
         hypervisor.cleanup
       end
 
       it 'cleans up vms' do
         expect(kubevirt_helper).to have_received(:cleanup_vms).with(anything)
+      end
+
+      it 'cleans up data volumes' do
+        expect(kubevirt_helper).to have_received(:cleanup_data_volumes).with(anything)
+      end
+
+      it 'cleans up data volumes after vms and before secrets' do
+        expect(kubevirt_helper).to have_received(:cleanup_vms).ordered
+        expect(kubevirt_helper).to have_received(:cleanup_data_volumes).ordered
+        expect(kubevirt_helper).to have_received(:cleanup_secrets).ordered
       end
 
       it 'cleans up secrets' do
@@ -129,6 +140,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
         allow(kubevirt_helper).to receive(:cleanup_temp_files)
+        allow(kubevirt_helper).to receive(:cleanup_data_volumes)
       end
 
       it 'still cleans up temp files when cleanup_vms raises' do
@@ -167,6 +179,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
         allow(kubevirt_helper).to receive(:cleanup_temp_files)
+        allow(kubevirt_helper).to receive(:cleanup_data_volumes)
         hypervisor_with_port_forward.cleanup(delay: 0.25)
       end
 
@@ -201,6 +214,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
         allow(kubevirt_helper).to receive(:cleanup_temp_files)
+        allow(kubevirt_helper).to receive(:cleanup_data_volumes)
         hypervisor_with_port_forward.cleanup
       end
 
@@ -235,6 +249,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
         allow(kubevirt_helper).to receive(:cleanup_temp_files)
+        allow(kubevirt_helper).to receive(:cleanup_data_volumes)
       end
 
       it 'does not raise and continues with cluster-side cleanup' do
@@ -1841,6 +1856,7 @@ RSpec.describe Beaker::Kubevirt do
       allow(kubevirt_helper).to receive(:cleanup_secrets)
       allow(kubevirt_helper).to receive(:cleanup_services)
       allow(kubevirt_helper).to receive(:cleanup_temp_files)
+      allow(kubevirt_helper).to receive(:cleanup_data_volumes)
     end
 
     describe '#initialize' do
@@ -1972,6 +1988,7 @@ RSpec.describe Beaker::Kubevirt do
         allow(kubevirt_helper).to receive(:cleanup_secrets)
         allow(kubevirt_helper).to receive(:cleanup_services)
         allow(kubevirt_helper).to receive(:cleanup_temp_files)
+        allow(kubevirt_helper).to receive(:cleanup_data_volumes)
       end
 
       it 'cleanup_on_exit does not perform cleanup' do


### PR DESCRIPTION
## Summary
- Add a best-effort CDI (\`cdi.kubevirt.io/v1beta1\`) client to \`KubevirtHelper\`; leaves it nil on clusters without CDI so nothing else changes.
- Add \`cleanup_data_volumes(test_group_identifier)\` selecting by the existing \`beaker/test-group\` label and hook it into \`cleanup_impl\` between VM and secret cleanup — VM first so the VMI releases the PVC before the DV delete reclaims storage.
- Fixes storage leaks when a VM create fails after its DataVolume is already created (owner-ref GC never fires).

## Test plan
- [x] \`bundle exec rake\`
- [ ] Integration: \`kubectl get dv,pvc -l beaker/test-group=<id>\` empty after cleanup on a KinD+CDI cluster.