### PR TITLE
Clean up port forwarder log levels and messages

### DIFF
--- a/lib/beaker/hypervisor/kubevirt.rb
+++ b/lib/beaker/hypervisor/kubevirt.rb
@@ -173,7 +173,7 @@ module Beaker
             sleep delay
           end
         rescue Timeout::Error
-          @logger.warn("Port-forwarder for host #{host_name} did not stop in time: ")
+          @logger.warn("Port-forwarder for host #{host_name} did not stop in time")
           raise
         rescue StandardError => e
           @logger.error("Error stopping port-forwarder for host #{host_name}: #{e}")
@@ -906,12 +906,10 @@ module Beaker
       host['ssh'] = ssh_options
 
       @logger.debug("Setting up port-forward for VM #{vm_name} from localhost:#{local_port} to VM port #{host_port}")
-      @logger.info("Configured SSH connection: host['ip']=#{host['ip']}, host['port']=#{host['port']}, host['ssh']['port']=#{host['ssh']['port']}")
+      @logger.debug("Configured SSH connection: host['ip']=#{host['ip']}, host['port']=#{host['port']}, host['ssh']['port']=#{host['ssh']['port']}")
 
       # Setup port forwarding from local_port to host_port (22) on the VM
       host['port_forwarder'] = @kubevirt_helper.setup_port_forward(vm_name, host_port, local_port)
-
-      @logger.info("Port forward setup for VM #{vm_name} on localhost:#{local_port}")
     end
 
     ##

--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -11,9 +11,10 @@ require 'json'
 # It handles the entire lifecycle of discovering the VMI, establishing a
 # WebSocket connection via the Kubernetes API, and proxying data.
 #
-# It is designed to be resilient, handling retries internally so that a client
-# (like Beaker's SSH client) can connect to the local port and simply wait
-# until the VMI is ready.
+# Each accepted client connection makes a single attempt to open the WebSocket
+# to the VMI. If that attempt fails, the client socket is closed so the caller
+# (e.g. Beaker's SSH client) sees the connection failure promptly and learns
+# the real state of the port, rather than waiting behind an internal retry loop.
 #
 # See the bottom of this file for a complete usage example.
 #
@@ -108,14 +109,15 @@ class KubeVirtPortForwarder
         begin
           # Accept a connection from a client (e.g., Beaker's SSH).
           client_socket = @server.accept
-          @logger.debug("Accepted connection from #{client_socket.peeraddr.join(':')}")
+          peer_ip, peer_port = client_socket.peeraddr(false).values_at(3, 1)
+          @logger.debug("Accepted connection from #{peer_ip}:#{peer_port}")
 
           # Handle the entire KubeVirt connection lifecycle in a new thread.
           conn_thread = Thread.new { handle_connection(client_socket) }
           @mutex.synchronize { @connection_threads << conn_thread }
         rescue IOError
           # This is expected when @server.close is called in stop()
-          @logger.info("Server on port #{@local_port} is shutting down.")
+          @logger.debug("Server on port #{@local_port} stopped accepting connections.")
           break
         end
       end
@@ -243,8 +245,9 @@ class KubeVirtPortForwarder
     @mutex.synchronize { @connection_threads.delete(Thread.current) }
   end
 
-  # Attempts to establish the WebSocket connection, retrying on failure.
-  # This is the core of the "wait for VM" logic.
+  # Attempts to establish the WebSocket connection. The retry loop is retained
+  # for flexibility, but callers pass retries: 1 so a failure is reported to
+  # the client immediately rather than masked by internal waiting.
   # @param client_socket [TCPSocket] The client socket, used to check if the client is still connected.
   # @return [Faye::WebSocket::Client, nil] The connected WebSocket client or nil if it fails.
   def establish_websocket_with_retry(client_socket, retries: 10, delay: 5)
@@ -272,7 +275,7 @@ class KubeVirtPortForwarder
     retries.times do |_i|
       return nil if client_socket.closed?
 
-      @logger.info("Attempting to connect to VMI '#{@vmi_name}'...")
+      @logger.debug("Opening WebSocket to VMI '#{@vmi_name}' port #{@target_port}")
 
       connection_status_q = Queue.new
 
@@ -281,8 +284,7 @@ class KubeVirtPortForwarder
         ws = Faye::WebSocket::Client.new(url, protocols, headers: headers, tls: tls_options)
 
         ws.on :open do |_event|
-          @logger.info("Connected to VMI '#{@vmi_name}'")
-          @logger.debug("WebSocket protocol: #{ws.protocol}")
+          @logger.debug("WebSocket open to VMI '#{@vmi_name}' (protocol: #{ws.protocol || 'none'})")
           connection_status_q.push(ws)
         end
 
@@ -290,7 +292,7 @@ class KubeVirtPortForwarder
         # to provide a more specific reason for the failure.
         ws.on :close do |event|
           if event.code == 1000 # Normal closure
-            @logger.info('WebSocket connection closed normally.')
+            @logger.debug('WebSocket connection closed normally.')
           else
             err_msg = "WebSocket closed unexpectedly. Code: #{event.code}, Reason: #{event.reason}"
 
@@ -325,9 +327,8 @@ class KubeVirtPortForwarder
 
       return result if result.is_a?(Faye::WebSocket::Client)
 
-      # Success!
       unless retries == 1
-        @logger.warn("Attempt failed. Retrying in #{delay} seconds...")
+        @logger.warn("WebSocket connect attempt failed. Retrying in #{delay} seconds...")
         sleep delay
       end
     end
@@ -340,9 +341,9 @@ class KubeVirtPortForwarder
   def proxy_traffic(client_socket, websocket)
     use_channels = (websocket.protocol == STREAM_PROTOCOL)
     if use_channels
-      @logger.info("Using multiplexed stream protocol: #{STREAM_PROTOCOL}")
+      @logger.debug("Using multiplexed stream protocol: #{STREAM_PROTOCOL}")
     else
-      @logger.info("Using raw stream protocol (negotiated: '#{websocket.protocol || 'none'}')")
+      @logger.debug("Using raw stream protocol (negotiated: '#{websocket.protocol || 'none'}')")
     end
 
     # Mutex to synchronize access to client_socket from multiple threads
@@ -411,7 +412,7 @@ class KubeVirtPortForwarder
     end
 
     websocket.on :close do |event|
-      @logger.info("WebSocket connection closed. Code: #{event.code}, Reason: #{event.reason}")
+      @logger.debug("WebSocket connection closed. Code: #{event.code}, Reason: #{event.reason}")
       socket_mutex.synchronize do
         client_socket.close
       rescue StandardError

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -1064,10 +1064,10 @@ RSpec.describe KubeVirtPortForwarder do
         end.not_to raise_error
 
         # Verify it logged the protocol without rejecting it
-        expect(logger).to have_received(:info).with(/Using raw stream protocol \(negotiated: '#{protocol || 'none'}'\)/)
+        expect(logger).to have_received(:debug).with(/Using raw stream protocol \(negotiated: '#{protocol || 'none'}'\)/)
 
         # Reset logger expectations for next iteration
-        allow(logger).to receive(:info)
+        allow(logger).to receive(:debug)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fix proxy log messages that misrepresented behavior (garbage `peeraddr.join(':')` output, stale `# Success!` comment, dangling `": "` in timeout warning).
- Rewrite the class-level doc and method docstring so they reflect the design: a single WebSocket attempt per client connection, with failures reported to the caller immediately instead of masked by an internal retry loop.
- Demote per-SSH-connection chatter (attempt / connected / protocol / close) from INFO to DEBUG, drop redundant INFOs (`Server on port X is shutting down`, `Port forward setup for VM …`), and demote the `Configured SSH connection` implementation-detail log in `setup_port_forward`.

## Test plan
- [x] `bundle exec rake` (292 examples, 0 failures; rubocop clean on changed files)
- [ ] Verify locally against a real KubeVirt cluster that INFO output is noticeably quieter while DEBUG still shows the per-connection detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)