### PR TITLE
Use /portforward/<port>/tcp form for VMI WebSocket URL

### DIFF
--- a/lib/beaker/hypervisor/port_forward.rb
+++ b/lib/beaker/hypervisor/port_forward.rb
@@ -270,7 +270,12 @@ class KubeVirtPortForwarder
     target_port = Integer(@target_port, exception: false)
     raise ArgumentError, "Invalid target port: #{@target_port.inspect}. Expected an integer between 1 and 65535." unless target_port&.between?(1, 65_535)
 
-    url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{ns}/virtualmachineinstances/#{vmi}/portforward/#{target_port}"
+    # Use the protocol-suffixed `/portforward/<port>/tcp` form. Both this and
+    # the bare `/portforward/<port>` route are registered in KubeVirt 1.7+,
+    # but some API-aggregation paths (notably Rancher's cluster proxy against
+    # KubeVirt 1.8) return 404 on the bare form. The `/tcp` form is what
+    # `virtctl port-forward` sends and works on every supported version.
+    url = "#{base_ws_url}/apis/subresources.kubevirt.io/v1/namespaces/#{ns}/virtualmachineinstances/#{vmi}/portforward/#{target_port}/tcp"
     @logger.debug("WebSocket URL: #{url}")
 
     auth_token = @kube_client.auth_options[:bearer_token]

--- a/spec/beaker/hypervisor/port_forward_spec.rb
+++ b/spec/beaker/hypervisor/port_forward_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe KubeVirtPortForwarder do
 
         forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
 
-        expect(captured_url).to eq('wss://kubernetes.example.com/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22')
+        expect(captured_url).to eq('wss://kubernetes.example.com/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22/tcp')
       end
 
       it 'constructs correct WebSocket URL with custom port' do
@@ -510,7 +510,7 @@ RSpec.describe KubeVirtPortForwarder do
 
         forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
 
-        expect(captured_url).to eq('wss://kubernetes.example.com:6443/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22')
+        expect(captured_url).to eq('wss://kubernetes.example.com:6443/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22/tcp')
       end
 
       it 'constructs correct WebSocket URL from Rancher-style endpoint' do
@@ -547,7 +547,7 @@ RSpec.describe KubeVirtPortForwarder do
         forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
 
         # The path prefix /k8s/clusters/local should be preserved
-        expect(captured_url).to eq('wss://rancher.example.com/k8s/clusters/local/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22')
+        expect(captured_url).to eq('wss://rancher.example.com/k8s/clusters/local/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22/tcp')
       end
 
       it 'constructs correct WebSocket URL from Rancher-style endpoint with /api path' do
@@ -586,7 +586,7 @@ RSpec.describe KubeVirtPortForwarder do
         forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
 
         # The /k8s/clusters/c-m-abcd1234 path should be preserved, but /api should be removed
-        expect(captured_url).to eq('wss://rancher.example.com/k8s/clusters/c-m-abcd1234/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22')
+        expect(captured_url).to eq('wss://rancher.example.com/k8s/clusters/c-m-abcd1234/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22/tcp')
       end
 
       it 'does not include default HTTPS port 443 in URL' do
@@ -623,7 +623,7 @@ RSpec.describe KubeVirtPortForwarder do
         forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
 
         # Port 443 should not appear in the URL
-        expect(captured_url).to eq('wss://kubernetes.example.com/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22')
+        expect(captured_url).to eq('wss://kubernetes.example.com/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22/tcp')
         expect(captured_url).not_to include(':443')
       end
 
@@ -662,7 +662,7 @@ RSpec.describe KubeVirtPortForwarder do
         forwarder.send(:establish_websocket_with_retry, client_socket, retries: 1, delay: 0)
 
         # Should not have double slashes in the path (after the protocol)
-        expect(captured_url).to eq('wss://kubernetes.example.com/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22')
+        expect(captured_url).to eq('wss://kubernetes.example.com/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/portforward/22/tcp')
         # Check that we don't have triple slashes or double slashes in the path
         expect(captured_url).not_to match(%r{://.*//})
       end


### PR DESCRIPTION
## Summary

- Switch the VMI port-forward WebSocket URL from `…/portforward/<port>` to the protocol-suffixed `…/portforward/<port>/tcp` form.
- After upgrading a downstream cluster from KubeVirt 1.7.0 → 1.8.2, all SSH-over-WebSocket-portforward attempts started failing with `WebSocket handshake: Unexpected response code: 404` (via Rancher's `…/k8s/clusters/<id>/apis/…` cluster proxy). The bare `/portforward/<port>` form returned 404 from the aggregated path, while the `/portforward/<port>/tcp` form is the canonical URL `virtctl port-forward` sends and works on every KubeVirt version this gem supports.

### Verification of compatibility

Both routes are registered for the VMI subresource in **both** v1.7.0 and v1.8.2:
- `pkg/virt-api/api.go` — both `subws.GET(... + PortPath)` and `subws.GET(... + PortPath + ProtocolPath)` registrations are present in both tags.
- `api/openapi-spec/swagger.json` — both tags list `…/portforward/{port}` and `…/portforward/{port}/{protocol}` paths.

So the `/tcp` suffix is strictly compatible with 1.7 and resolves the 404 observed under 1.8 + Rancher's API aggregator.

## Test plan

- [x] `bundle exec rake spec` — 317 examples, 0 failures
- [x] `bundle exec rubocop` on the changed files — clean
- [ ] End-to-end: re-run the failing acceptance flow against KubeVirt 1.8.2 behind Rancher's cluster proxy and confirm the SSH session establishes (no in-repo harness for this — needs a live cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)